### PR TITLE
Rename rate to daily_rate

### DIFF
--- a/client/Assets/Scripts/AfkRewards/AfkRewardRate.cs
+++ b/client/Assets/Scripts/AfkRewards/AfkRewardRate.cs
@@ -2,5 +2,5 @@ public class AfkRewardRate
 {
     public string kalineTreeLevelId;
     public string currency;
-    public float rate;
+    public float daily_rate;
 }

--- a/client/Assets/Scripts/AfkRewards/KalineTreeManager.cs
+++ b/client/Assets/Scripts/AfkRewards/KalineTreeManager.cs
@@ -17,6 +17,8 @@ public class KalineTreeManager : MonoBehaviour
     [SerializeField] GameObject afkRewardDetailUI;
     [SerializeField] GameObject afkRewardsContainer;
 
+    private const int MINUTES_IN_DAY = 1440;
+
     void Start()
     {
         GlobalUserData user = GlobalUserData.Instance;
@@ -40,7 +42,7 @@ public class KalineTreeManager : MonoBehaviour
             {
                 GameObject afkRewardGO = Instantiate(afkRewardDetailUI, afkRewardsContainer.transform);
                 AfkRewardDetail afkRewardDetail = afkRewardGO.GetComponent<AfkRewardDetail>();
-                afkRewardDetail.SetData(GlobalUserData.Instance.AvailableCurrencies.Single(currency => currency.name == afkReward.currency).image, $"{afkReward.amount} ({user.User.kalineTreeLevel.afkRewardRates.Single(arr => arr.currency == afkReward.currency).daily_rate * 60}/m)");
+                afkRewardDetail.SetData(GlobalUserData.Instance.AvailableCurrencies.Single(currency => currency.name == afkReward.currency).image, $"{afkReward.amount} ({user.User.kalineTreeLevel.afkRewardRates.Single(arr => arr.currency == afkReward.currency).daily_rate / (MINUTES_IN_DAY)}/m)");
             }
 
             confirmPopUp.SetActive(true);

--- a/client/Assets/Scripts/AfkRewards/KalineTreeManager.cs
+++ b/client/Assets/Scripts/AfkRewards/KalineTreeManager.cs
@@ -16,7 +16,6 @@ public class KalineTreeManager : MonoBehaviour
     [SerializeField] GameObject insufficientCurrencyPopup;
     [SerializeField] GameObject afkRewardDetailUI;
     [SerializeField] GameObject afkRewardsContainer;
-    private const int SECONDS_IN_DAY = 86400;
 
     void Start()
     {
@@ -132,6 +131,6 @@ public class KalineTreeManager : MonoBehaviour
 
     private string GetAfkRewardRateText(float daily_rate)
     {
-        return $"{daily_rate * SECONDS_IN_DAY}/day";
+        return $"{daily_rate}/day";
     }
 }

--- a/client/Assets/Scripts/AfkRewards/KalineTreeManager.cs
+++ b/client/Assets/Scripts/AfkRewards/KalineTreeManager.cs
@@ -37,11 +37,11 @@ public class KalineTreeManager : MonoBehaviour
                 Destroy(child.gameObject);
             }
 
-            foreach (var afkReward in afkRewards.Where(reward => user.User.kalineTreeLevel.afkRewardRates.Any(rewardRate => rewardRate.rate > 0 && rewardRate.currency == reward.currency)))
+            foreach (var afkReward in afkRewards.Where(reward => user.User.kalineTreeLevel.afkRewardRates.Any(rewardRate => rewardRate.daily_rate > 0 && rewardRate.currency == reward.currency)))
             {
                 GameObject afkRewardGO = Instantiate(afkRewardDetailUI, afkRewardsContainer.transform);
                 AfkRewardDetail afkRewardDetail = afkRewardGO.GetComponent<AfkRewardDetail>();
-                afkRewardDetail.SetData(GlobalUserData.Instance.AvailableCurrencies.Single(currency => currency.name == afkReward.currency).image, $"{afkReward.amount} ({user.User.kalineTreeLevel.afkRewardRates.Single(arr => arr.currency == afkReward.currency).rate * 60}/m)");
+                afkRewardDetail.SetData(GlobalUserData.Instance.AvailableCurrencies.Single(currency => currency.name == afkReward.currency).image, $"{afkReward.amount} ({user.User.kalineTreeLevel.afkRewardRates.Single(arr => arr.currency == afkReward.currency).daily_rate * 60}/m)");
             }
 
             confirmPopUp.SetActive(true);
@@ -115,23 +115,23 @@ public class KalineTreeManager : MonoBehaviour
             switch (afkRewardRate.currency)
             {
                 case "Gold":
-                    goldAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.rate);
+                    goldAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.daily_rate);
                     break;
                 case "Hero Souls":
-                    heroSoulsAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.rate);
+                    heroSoulsAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.daily_rate);
                     break;
                 case "Experience":
-                    experienceAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.rate);
+                    experienceAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.daily_rate);
                     break;
                 case "Arcane Crystals":
-                    arcaneCrystalsAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.rate);
+                    arcaneCrystalsAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.daily_rate);
                     break;
             }
         }
     }
 
-    private string GetAfkRewardRateText(float rate)
+    private string GetAfkRewardRateText(float daily_rate)
     {
-        return $"{rate * SECONDS_IN_DAY}/day";
+        return $"{daily_rate * SECONDS_IN_DAY}/day";
     }
 }

--- a/client/Assets/Scripts/BackendConnection/SocketConnection.cs
+++ b/client/Assets/Scripts/BackendConnection/SocketConnection.cs
@@ -202,7 +202,7 @@ public class SocketConnection : MonoBehaviour
         {
             kalineTreeLevelId = afkRewardRateData.KalineTreeLevelId,
             currency = afkRewardRateData.Currency.Name,
-            daily_rate = afkRewardRateData.daily_rate
+            daily_rate = afkRewardRateData.DailyRate
         };
     }
 

--- a/client/Assets/Scripts/BackendConnection/SocketConnection.cs
+++ b/client/Assets/Scripts/BackendConnection/SocketConnection.cs
@@ -191,7 +191,7 @@ public class SocketConnection : MonoBehaviour
         {
             kalineTreeLevelId = afkRewardRateData.KalineTreeLevelId,
             currency = afkRewardRateData.Currency.Name,
-            rate = afkRewardRateData.Rate
+            daily_rate = afkRewardRateData.daily_rate
         };
     }
 

--- a/client/Assets/Scripts/Campaign/LevelData.cs
+++ b/client/Assets/Scripts/Campaign/LevelData.cs
@@ -11,7 +11,7 @@ public class LevelData
 
     public Dictionary<string, int> rewards = new Dictionary<string, int>();
 
-    // AFK Rewards rate granted
+    // AFK Rewards daily_rate granted
     // These are how many a player makes in the maximum timespan available (12h now)
     public Dictionary<Currency, int> afkCurrencyRate = new Dictionary<Currency, int>();
 

--- a/client/Assets/Scripts/Dungeon/DungeonSettlementManager.cs
+++ b/client/Assets/Scripts/Dungeon/DungeonSettlementManager.cs
@@ -76,7 +76,7 @@ public class DungeonSettlementManager : MonoBehaviour
         {
             if (afkRewardRate.currency == "Supplies")
             {
-                suppliesAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.rate);
+                suppliesAfkRewardRate.text = GetAfkRewardRateText(afkRewardRate.daily_rate);
             }
             else
             {

--- a/client/Assets/Scripts/Dungeon/DungeonSettlementManager.cs
+++ b/client/Assets/Scripts/Dungeon/DungeonSettlementManager.cs
@@ -85,8 +85,8 @@ public class DungeonSettlementManager : MonoBehaviour
         }
     }
 
-    private string GetAfkRewardRateText(float rate)
+    private string GetAfkRewardRateText(float daily_rate)
     {
-        return $"{rate * SECONDS_IN_DAY}/day";
+        return $"{daily_rate}/day";
     }
 }

--- a/client/Assets/Scripts/Dungeon/DungeonSettlementManager.cs
+++ b/client/Assets/Scripts/Dungeon/DungeonSettlementManager.cs
@@ -12,7 +12,6 @@ public class DungeonSettlementManager : MonoBehaviour
     [SerializeField] GameObject confirmPopUp;
     [SerializeField] GameObject insufficientCurrencyPopup;
     [SerializeField] GameObject levelUpButton;
-    private const int SECONDS_IN_DAY = 86400;
 
     void Start()
     {

--- a/client/Assets/Scripts/Protobuf/Gateway.pb.cs
+++ b/client/Assets/Scripts/Protobuf/Gateway.pb.cs
@@ -9,19 +9,23 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace Protobuf.Messages {
+namespace Protobuf.Messages
+{
 
   /// <summary>Holder for reflection information generated from gateway.proto</summary>
-  public static partial class GatewayReflection {
+  public static partial class GatewayReflection
+  {
 
     #region Descriptor
     /// <summary>File descriptor for gateway.proto</summary>
-    public static pbr::FileDescriptor Descriptor {
+    public static pbr::FileDescriptor Descriptor
+    {
       get { return descriptor; }
     }
     private static pbr::FileDescriptor descriptor;
 
-    static GatewayReflection() {
+    static GatewayReflection()
+    {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "Cg1nYXRld2F5LnByb3RvIqMHChBXZWJTb2NrZXRSZXF1ZXN0EhwKCGdldF91",
@@ -166,7 +170,7 @@ namespace Protobuf.Messages {
             "ZXNiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Protobuf.Messages.SkillActionType), typeof(global::Protobuf.Messages.Stat), }, null, new pbr::GeneratedClrTypeInfo[] {
+          new pbr::GeneratedClrTypeInfo(new[] { typeof(global::Protobuf.Messages.SkillActionType), typeof(global::Protobuf.Messages.Stat), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.WebSocketRequest), global::Protobuf.Messages.WebSocketRequest.Parser, new[]{ "GetUser", "GetUserByUsername", "CreateUser", "GetCampaigns", "GetCampaign", "GetLevel", "FightLevel", "SelectUnit", "UnselectUnit", "LevelUpUnit", "TierUpUnit", "FuseUnit", "EquipItem", "UnequipItem", "GetItem", "LevelUpItem", "GetBoxes", "GetBox", "Summon", "GetAfkRewards", "ClaimAfkRewards", "GetUserSuperCampaignProgresses", "LevelUpKalineTree" }, new[]{ "RequestType" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.GetUser), global::Protobuf.Messages.GetUser.Parser, new[]{ "UserId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.GetUserByUsername), global::Protobuf.Messages.GetUserByUsername.Parser, new[]{ "Username" }, null, null, null, null),
@@ -196,7 +200,7 @@ namespace Protobuf.Messages {
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.KalineTreeLevel), global::Protobuf.Messages.KalineTreeLevel.Parser, new[]{ "Id", "Level", "FertilizerLevelUpCost", "GoldLevelUpCost", "UnlockFeatures", "AfkRewardRates" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.SuperCampaignProgresses), global::Protobuf.Messages.SuperCampaignProgresses.Parser, new[]{ "SuperCampaignProgresses_" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.SuperCampaignProgress), global::Protobuf.Messages.SuperCampaignProgress.Parser, new[]{ "UserId", "CampaignId", "LevelId", "SuperCampaignName" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.AfkRewardRate), global::Protobuf.Messages.AfkRewardRate.Parser, new[]{ "KalineTreeLevelId", "Currency", "Rate" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.AfkRewardRate), global::Protobuf.Messages.AfkRewardRate.Parser, new[]{ "KalineTreeLevelId", "Currency", "daily_rate" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.UserCurrency), global::Protobuf.Messages.UserCurrency.Parser, new[]{ "Currency", "Amount" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.Currency), global::Protobuf.Messages.Currency.Parser, new[]{ "Name" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Protobuf.Messages.Unit), global::Protobuf.Messages.Unit.Parser, new[]{ "Id", "Level", "Tier", "Rank", "Selected", "Slot", "CampaignLevelId", "UserId", "Character", "Items" }, null, null, null, null),
@@ -238,14 +242,16 @@ namespace Protobuf.Messages {
 
   }
   #region Enums
-  public enum SkillActionType {
+  public enum SkillActionType
+  {
     [pbr::OriginalName("ANIMATION_START")] AnimationStart = 0,
     [pbr::OriginalName("EFFECT_TRIGGER")] EffectTrigger = 1,
     [pbr::OriginalName("EFFECT_HIT")] EffectHit = 2,
     [pbr::OriginalName("EFFECT_MISS")] EffectMiss = 3,
   }
 
-  public enum Stat {
+  public enum Stat
+  {
     [pbr::OriginalName("HEALTH")] Health = 0,
     [pbr::OriginalName("ENERGY")] Energy = 1,
     [pbr::OriginalName("ATTACK")] Attack = 2,
@@ -259,9 +265,9 @@ namespace Protobuf.Messages {
   #region Messages
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WebSocketRequest : pb::IMessage<WebSocketRequest>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<WebSocketRequest> _parser = new pb::MessageParser<WebSocketRequest>(() => new WebSocketRequest());
     private pb::UnknownFieldSet _unknownFields;
@@ -271,19 +277,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[0]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public WebSocketRequest() {
+    public WebSocketRequest()
+    {
       OnConstruction();
     }
 
@@ -291,8 +300,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public WebSocketRequest(WebSocketRequest other) : this() {
-      switch (other.RequestTypeCase) {
+    public WebSocketRequest(WebSocketRequest other) : this()
+    {
+      switch (other.RequestTypeCase)
+      {
         case RequestTypeOneofCase.GetUser:
           GetUser = other.GetUser.Clone();
           break;
@@ -369,7 +380,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public WebSocketRequest Clone() {
+    public WebSocketRequest Clone()
+    {
       return new WebSocketRequest(this);
     }
 
@@ -377,9 +389,11 @@ namespace Protobuf.Messages {
     public const int GetUserFieldNumber = 1;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetUser GetUser {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetUser ? (global::Protobuf.Messages.GetUser) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetUser GetUser
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetUser ? (global::Protobuf.Messages.GetUser)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetUser;
       }
@@ -389,9 +403,11 @@ namespace Protobuf.Messages {
     public const int GetUserByUsernameFieldNumber = 2;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetUserByUsername GetUserByUsername {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername ? (global::Protobuf.Messages.GetUserByUsername) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetUserByUsername GetUserByUsername
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername ? (global::Protobuf.Messages.GetUserByUsername)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetUserByUsername;
       }
@@ -401,9 +417,11 @@ namespace Protobuf.Messages {
     public const int CreateUserFieldNumber = 3;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.CreateUser CreateUser {
-      get { return requestTypeCase_ == RequestTypeOneofCase.CreateUser ? (global::Protobuf.Messages.CreateUser) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.CreateUser CreateUser
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.CreateUser ? (global::Protobuf.Messages.CreateUser)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.CreateUser;
       }
@@ -413,9 +431,11 @@ namespace Protobuf.Messages {
     public const int GetCampaignsFieldNumber = 4;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetCampaigns GetCampaigns {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetCampaigns ? (global::Protobuf.Messages.GetCampaigns) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetCampaigns GetCampaigns
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetCampaigns ? (global::Protobuf.Messages.GetCampaigns)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetCampaigns;
       }
@@ -425,9 +445,11 @@ namespace Protobuf.Messages {
     public const int GetCampaignFieldNumber = 5;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetCampaign GetCampaign {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetCampaign ? (global::Protobuf.Messages.GetCampaign) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetCampaign GetCampaign
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetCampaign ? (global::Protobuf.Messages.GetCampaign)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetCampaign;
       }
@@ -437,9 +459,11 @@ namespace Protobuf.Messages {
     public const int GetLevelFieldNumber = 6;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetLevel GetLevel {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetLevel ? (global::Protobuf.Messages.GetLevel) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetLevel GetLevel
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetLevel ? (global::Protobuf.Messages.GetLevel)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetLevel;
       }
@@ -449,9 +473,11 @@ namespace Protobuf.Messages {
     public const int FightLevelFieldNumber = 7;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.FightLevel FightLevel {
-      get { return requestTypeCase_ == RequestTypeOneofCase.FightLevel ? (global::Protobuf.Messages.FightLevel) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.FightLevel FightLevel
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.FightLevel ? (global::Protobuf.Messages.FightLevel)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.FightLevel;
       }
@@ -461,9 +487,11 @@ namespace Protobuf.Messages {
     public const int SelectUnitFieldNumber = 9;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.SelectUnit SelectUnit {
-      get { return requestTypeCase_ == RequestTypeOneofCase.SelectUnit ? (global::Protobuf.Messages.SelectUnit) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.SelectUnit SelectUnit
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.SelectUnit ? (global::Protobuf.Messages.SelectUnit)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.SelectUnit;
       }
@@ -473,9 +501,11 @@ namespace Protobuf.Messages {
     public const int UnselectUnitFieldNumber = 10;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.UnselectUnit UnselectUnit {
-      get { return requestTypeCase_ == RequestTypeOneofCase.UnselectUnit ? (global::Protobuf.Messages.UnselectUnit) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.UnselectUnit UnselectUnit
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.UnselectUnit ? (global::Protobuf.Messages.UnselectUnit)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.UnselectUnit;
       }
@@ -485,9 +515,11 @@ namespace Protobuf.Messages {
     public const int LevelUpUnitFieldNumber = 11;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.LevelUpUnit LevelUpUnit {
-      get { return requestTypeCase_ == RequestTypeOneofCase.LevelUpUnit ? (global::Protobuf.Messages.LevelUpUnit) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.LevelUpUnit LevelUpUnit
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.LevelUpUnit ? (global::Protobuf.Messages.LevelUpUnit)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.LevelUpUnit;
       }
@@ -497,9 +529,11 @@ namespace Protobuf.Messages {
     public const int TierUpUnitFieldNumber = 12;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.TierUpUnit TierUpUnit {
-      get { return requestTypeCase_ == RequestTypeOneofCase.TierUpUnit ? (global::Protobuf.Messages.TierUpUnit) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.TierUpUnit TierUpUnit
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.TierUpUnit ? (global::Protobuf.Messages.TierUpUnit)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.TierUpUnit;
       }
@@ -509,9 +543,11 @@ namespace Protobuf.Messages {
     public const int FuseUnitFieldNumber = 13;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.FuseUnit FuseUnit {
-      get { return requestTypeCase_ == RequestTypeOneofCase.FuseUnit ? (global::Protobuf.Messages.FuseUnit) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.FuseUnit FuseUnit
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.FuseUnit ? (global::Protobuf.Messages.FuseUnit)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.FuseUnit;
       }
@@ -521,9 +557,11 @@ namespace Protobuf.Messages {
     public const int EquipItemFieldNumber = 14;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.EquipItem EquipItem {
-      get { return requestTypeCase_ == RequestTypeOneofCase.EquipItem ? (global::Protobuf.Messages.EquipItem) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.EquipItem EquipItem
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.EquipItem ? (global::Protobuf.Messages.EquipItem)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.EquipItem;
       }
@@ -533,9 +571,11 @@ namespace Protobuf.Messages {
     public const int UnequipItemFieldNumber = 15;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.UnequipItem UnequipItem {
-      get { return requestTypeCase_ == RequestTypeOneofCase.UnequipItem ? (global::Protobuf.Messages.UnequipItem) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.UnequipItem UnequipItem
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.UnequipItem ? (global::Protobuf.Messages.UnequipItem)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.UnequipItem;
       }
@@ -545,9 +585,11 @@ namespace Protobuf.Messages {
     public const int GetItemFieldNumber = 16;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetItem GetItem {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetItem ? (global::Protobuf.Messages.GetItem) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetItem GetItem
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetItem ? (global::Protobuf.Messages.GetItem)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetItem;
       }
@@ -557,9 +599,11 @@ namespace Protobuf.Messages {
     public const int LevelUpItemFieldNumber = 17;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.LevelUpItem LevelUpItem {
-      get { return requestTypeCase_ == RequestTypeOneofCase.LevelUpItem ? (global::Protobuf.Messages.LevelUpItem) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.LevelUpItem LevelUpItem
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.LevelUpItem ? (global::Protobuf.Messages.LevelUpItem)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.LevelUpItem;
       }
@@ -569,9 +613,11 @@ namespace Protobuf.Messages {
     public const int GetBoxesFieldNumber = 18;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetBoxes GetBoxes {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetBoxes ? (global::Protobuf.Messages.GetBoxes) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetBoxes GetBoxes
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetBoxes ? (global::Protobuf.Messages.GetBoxes)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetBoxes;
       }
@@ -581,9 +627,11 @@ namespace Protobuf.Messages {
     public const int GetBoxFieldNumber = 19;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetBox GetBox {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetBox ? (global::Protobuf.Messages.GetBox) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetBox GetBox
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetBox ? (global::Protobuf.Messages.GetBox)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetBox;
       }
@@ -593,9 +641,11 @@ namespace Protobuf.Messages {
     public const int SummonFieldNumber = 20;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Summon Summon {
-      get { return requestTypeCase_ == RequestTypeOneofCase.Summon ? (global::Protobuf.Messages.Summon) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.Summon Summon
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.Summon ? (global::Protobuf.Messages.Summon)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.Summon;
       }
@@ -605,9 +655,11 @@ namespace Protobuf.Messages {
     public const int GetAfkRewardsFieldNumber = 21;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetAfkRewards GetAfkRewards {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetAfkRewards ? (global::Protobuf.Messages.GetAfkRewards) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetAfkRewards GetAfkRewards
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetAfkRewards ? (global::Protobuf.Messages.GetAfkRewards)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetAfkRewards;
       }
@@ -617,9 +669,11 @@ namespace Protobuf.Messages {
     public const int ClaimAfkRewardsFieldNumber = 22;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.ClaimAfkRewards ClaimAfkRewards {
-      get { return requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards ? (global::Protobuf.Messages.ClaimAfkRewards) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.ClaimAfkRewards ClaimAfkRewards
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards ? (global::Protobuf.Messages.ClaimAfkRewards)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.ClaimAfkRewards;
       }
@@ -629,9 +683,11 @@ namespace Protobuf.Messages {
     public const int GetUserSuperCampaignProgressesFieldNumber = 23;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.GetUserSuperCampaignProgresses GetUserSuperCampaignProgresses {
-      get { return requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses ? (global::Protobuf.Messages.GetUserSuperCampaignProgresses) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.GetUserSuperCampaignProgresses GetUserSuperCampaignProgresses
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses ? (global::Protobuf.Messages.GetUserSuperCampaignProgresses)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.GetUserSuperCampaignProgresses;
       }
@@ -641,9 +697,11 @@ namespace Protobuf.Messages {
     public const int LevelUpKalineTreeFieldNumber = 24;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.LevelUpKalineTree LevelUpKalineTree {
-      get { return requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree ? (global::Protobuf.Messages.LevelUpKalineTree) requestType_ : null; }
-      set {
+    public global::Protobuf.Messages.LevelUpKalineTree LevelUpKalineTree
+    {
+      get { return requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree ? (global::Protobuf.Messages.LevelUpKalineTree)requestType_ : null; }
+      set
+      {
         requestType_ = value;
         requestTypeCase_ = value == null ? RequestTypeOneofCase.None : RequestTypeOneofCase.LevelUpKalineTree;
       }
@@ -651,7 +709,8 @@ namespace Protobuf.Messages {
 
     private object requestType_;
     /// <summary>Enum of possible cases for the "request_type" oneof.</summary>
-    public enum RequestTypeOneofCase {
+    public enum RequestTypeOneofCase
+    {
       None = 0,
       GetUser = 1,
       GetUserByUsername = 2,
@@ -680,30 +739,36 @@ namespace Protobuf.Messages {
     private RequestTypeOneofCase requestTypeCase_ = RequestTypeOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public RequestTypeOneofCase RequestTypeCase {
+    public RequestTypeOneofCase RequestTypeCase
+    {
       get { return requestTypeCase_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void ClearRequestType() {
+    public void ClearRequestType()
+    {
       requestTypeCase_ = RequestTypeOneofCase.None;
       requestType_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as WebSocketRequest);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(WebSocketRequest other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(WebSocketRequest other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(GetUser, other.GetUser)) return false;
@@ -735,7 +800,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (requestTypeCase_ == RequestTypeOneofCase.GetUser) hash ^= GetUser.GetHashCode();
       if (requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername) hash ^= GetUserByUsername.GetHashCode();
@@ -760,8 +826,9 @@ namespace Protobuf.Messages {
       if (requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards) hash ^= ClaimAfkRewards.GetHashCode();
       if (requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses) hash ^= GetUserSuperCampaignProgresses.GetHashCode();
       if (requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree) hash ^= LevelUpKalineTree.GetHashCode();
-      hash ^= (int) requestTypeCase_;
-      if (_unknownFields != null) {
+      hash ^= (int)requestTypeCase_;
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -769,16 +836,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (requestTypeCase_ == RequestTypeOneofCase.GetUser) {
         output.WriteRawTag(10);
         output.WriteMessage(GetUser);
@@ -874,185 +943,235 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (requestTypeCase_ == RequestTypeOneofCase.GetUser) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetUser)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(GetUser);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername)
+      {
         output.WriteRawTag(18);
         output.WriteMessage(GetUserByUsername);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.CreateUser) {
+      if (requestTypeCase_ == RequestTypeOneofCase.CreateUser)
+      {
         output.WriteRawTag(26);
         output.WriteMessage(CreateUser);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetCampaigns) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetCampaigns)
+      {
         output.WriteRawTag(34);
         output.WriteMessage(GetCampaigns);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetCampaign) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetCampaign)
+      {
         output.WriteRawTag(42);
         output.WriteMessage(GetCampaign);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetLevel) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetLevel)
+      {
         output.WriteRawTag(50);
         output.WriteMessage(GetLevel);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.FightLevel) {
+      if (requestTypeCase_ == RequestTypeOneofCase.FightLevel)
+      {
         output.WriteRawTag(58);
         output.WriteMessage(FightLevel);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.SelectUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.SelectUnit)
+      {
         output.WriteRawTag(74);
         output.WriteMessage(SelectUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.UnselectUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.UnselectUnit)
+      {
         output.WriteRawTag(82);
         output.WriteMessage(UnselectUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpUnit)
+      {
         output.WriteRawTag(90);
         output.WriteMessage(LevelUpUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.TierUpUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.TierUpUnit)
+      {
         output.WriteRawTag(98);
         output.WriteMessage(TierUpUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.FuseUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.FuseUnit)
+      {
         output.WriteRawTag(106);
         output.WriteMessage(FuseUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.EquipItem) {
+      if (requestTypeCase_ == RequestTypeOneofCase.EquipItem)
+      {
         output.WriteRawTag(114);
         output.WriteMessage(EquipItem);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.UnequipItem) {
+      if (requestTypeCase_ == RequestTypeOneofCase.UnequipItem)
+      {
         output.WriteRawTag(122);
         output.WriteMessage(UnequipItem);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetItem) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetItem)
+      {
         output.WriteRawTag(130, 1);
         output.WriteMessage(GetItem);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpItem) {
+      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpItem)
+      {
         output.WriteRawTag(138, 1);
         output.WriteMessage(LevelUpItem);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetBoxes) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetBoxes)
+      {
         output.WriteRawTag(146, 1);
         output.WriteMessage(GetBoxes);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetBox) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetBox)
+      {
         output.WriteRawTag(154, 1);
         output.WriteMessage(GetBox);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.Summon) {
+      if (requestTypeCase_ == RequestTypeOneofCase.Summon)
+      {
         output.WriteRawTag(162, 1);
         output.WriteMessage(Summon);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetAfkRewards) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetAfkRewards)
+      {
         output.WriteRawTag(170, 1);
         output.WriteMessage(GetAfkRewards);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards) {
+      if (requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards)
+      {
         output.WriteRawTag(178, 1);
         output.WriteMessage(ClaimAfkRewards);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses)
+      {
         output.WriteRawTag(186, 1);
         output.WriteMessage(GetUserSuperCampaignProgresses);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree) {
+      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree)
+      {
         output.WriteRawTag(194, 1);
         output.WriteMessage(LevelUpKalineTree);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (requestTypeCase_ == RequestTypeOneofCase.GetUser) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetUser)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(GetUser);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(GetUserByUsername);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.CreateUser) {
+      if (requestTypeCase_ == RequestTypeOneofCase.CreateUser)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(CreateUser);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetCampaigns) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetCampaigns)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(GetCampaigns);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetCampaign) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetCampaign)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(GetCampaign);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetLevel) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetLevel)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(GetLevel);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.FightLevel) {
+      if (requestTypeCase_ == RequestTypeOneofCase.FightLevel)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(FightLevel);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.SelectUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.SelectUnit)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(SelectUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.UnselectUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.UnselectUnit)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(UnselectUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpUnit)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(LevelUpUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.TierUpUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.TierUpUnit)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(TierUpUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.FuseUnit) {
+      if (requestTypeCase_ == RequestTypeOneofCase.FuseUnit)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(FuseUnit);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.EquipItem) {
+      if (requestTypeCase_ == RequestTypeOneofCase.EquipItem)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(EquipItem);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.UnequipItem) {
+      if (requestTypeCase_ == RequestTypeOneofCase.UnequipItem)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(UnequipItem);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetItem) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetItem)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetItem);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpItem) {
+      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpItem)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(LevelUpItem);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetBoxes) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetBoxes)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetBoxes);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetBox) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetBox)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetBox);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.Summon) {
+      if (requestTypeCase_ == RequestTypeOneofCase.Summon)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(Summon);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetAfkRewards) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetAfkRewards)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetAfkRewards);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards) {
+      if (requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(ClaimAfkRewards);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses) {
+      if (requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetUserSuperCampaignProgresses);
       }
-      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree) {
+      if (requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree)
+      {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(LevelUpKalineTree);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -1060,145 +1179,171 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(WebSocketRequest other) {
-      if (other == null) {
+    public void MergeFrom(WebSocketRequest other)
+    {
+      if (other == null)
+      {
         return;
       }
-      switch (other.RequestTypeCase) {
+      switch (other.RequestTypeCase)
+      {
         case RequestTypeOneofCase.GetUser:
-          if (GetUser == null) {
+          if (GetUser == null)
+          {
             GetUser = new global::Protobuf.Messages.GetUser();
           }
           GetUser.MergeFrom(other.GetUser);
           break;
         case RequestTypeOneofCase.GetUserByUsername:
-          if (GetUserByUsername == null) {
+          if (GetUserByUsername == null)
+          {
             GetUserByUsername = new global::Protobuf.Messages.GetUserByUsername();
           }
           GetUserByUsername.MergeFrom(other.GetUserByUsername);
           break;
         case RequestTypeOneofCase.CreateUser:
-          if (CreateUser == null) {
+          if (CreateUser == null)
+          {
             CreateUser = new global::Protobuf.Messages.CreateUser();
           }
           CreateUser.MergeFrom(other.CreateUser);
           break;
         case RequestTypeOneofCase.GetCampaigns:
-          if (GetCampaigns == null) {
+          if (GetCampaigns == null)
+          {
             GetCampaigns = new global::Protobuf.Messages.GetCampaigns();
           }
           GetCampaigns.MergeFrom(other.GetCampaigns);
           break;
         case RequestTypeOneofCase.GetCampaign:
-          if (GetCampaign == null) {
+          if (GetCampaign == null)
+          {
             GetCampaign = new global::Protobuf.Messages.GetCampaign();
           }
           GetCampaign.MergeFrom(other.GetCampaign);
           break;
         case RequestTypeOneofCase.GetLevel:
-          if (GetLevel == null) {
+          if (GetLevel == null)
+          {
             GetLevel = new global::Protobuf.Messages.GetLevel();
           }
           GetLevel.MergeFrom(other.GetLevel);
           break;
         case RequestTypeOneofCase.FightLevel:
-          if (FightLevel == null) {
+          if (FightLevel == null)
+          {
             FightLevel = new global::Protobuf.Messages.FightLevel();
           }
           FightLevel.MergeFrom(other.FightLevel);
           break;
         case RequestTypeOneofCase.SelectUnit:
-          if (SelectUnit == null) {
+          if (SelectUnit == null)
+          {
             SelectUnit = new global::Protobuf.Messages.SelectUnit();
           }
           SelectUnit.MergeFrom(other.SelectUnit);
           break;
         case RequestTypeOneofCase.UnselectUnit:
-          if (UnselectUnit == null) {
+          if (UnselectUnit == null)
+          {
             UnselectUnit = new global::Protobuf.Messages.UnselectUnit();
           }
           UnselectUnit.MergeFrom(other.UnselectUnit);
           break;
         case RequestTypeOneofCase.LevelUpUnit:
-          if (LevelUpUnit == null) {
+          if (LevelUpUnit == null)
+          {
             LevelUpUnit = new global::Protobuf.Messages.LevelUpUnit();
           }
           LevelUpUnit.MergeFrom(other.LevelUpUnit);
           break;
         case RequestTypeOneofCase.TierUpUnit:
-          if (TierUpUnit == null) {
+          if (TierUpUnit == null)
+          {
             TierUpUnit = new global::Protobuf.Messages.TierUpUnit();
           }
           TierUpUnit.MergeFrom(other.TierUpUnit);
           break;
         case RequestTypeOneofCase.FuseUnit:
-          if (FuseUnit == null) {
+          if (FuseUnit == null)
+          {
             FuseUnit = new global::Protobuf.Messages.FuseUnit();
           }
           FuseUnit.MergeFrom(other.FuseUnit);
           break;
         case RequestTypeOneofCase.EquipItem:
-          if (EquipItem == null) {
+          if (EquipItem == null)
+          {
             EquipItem = new global::Protobuf.Messages.EquipItem();
           }
           EquipItem.MergeFrom(other.EquipItem);
           break;
         case RequestTypeOneofCase.UnequipItem:
-          if (UnequipItem == null) {
+          if (UnequipItem == null)
+          {
             UnequipItem = new global::Protobuf.Messages.UnequipItem();
           }
           UnequipItem.MergeFrom(other.UnequipItem);
           break;
         case RequestTypeOneofCase.GetItem:
-          if (GetItem == null) {
+          if (GetItem == null)
+          {
             GetItem = new global::Protobuf.Messages.GetItem();
           }
           GetItem.MergeFrom(other.GetItem);
           break;
         case RequestTypeOneofCase.LevelUpItem:
-          if (LevelUpItem == null) {
+          if (LevelUpItem == null)
+          {
             LevelUpItem = new global::Protobuf.Messages.LevelUpItem();
           }
           LevelUpItem.MergeFrom(other.LevelUpItem);
           break;
         case RequestTypeOneofCase.GetBoxes:
-          if (GetBoxes == null) {
+          if (GetBoxes == null)
+          {
             GetBoxes = new global::Protobuf.Messages.GetBoxes();
           }
           GetBoxes.MergeFrom(other.GetBoxes);
           break;
         case RequestTypeOneofCase.GetBox:
-          if (GetBox == null) {
+          if (GetBox == null)
+          {
             GetBox = new global::Protobuf.Messages.GetBox();
           }
           GetBox.MergeFrom(other.GetBox);
           break;
         case RequestTypeOneofCase.Summon:
-          if (Summon == null) {
+          if (Summon == null)
+          {
             Summon = new global::Protobuf.Messages.Summon();
           }
           Summon.MergeFrom(other.Summon);
           break;
         case RequestTypeOneofCase.GetAfkRewards:
-          if (GetAfkRewards == null) {
+          if (GetAfkRewards == null)
+          {
             GetAfkRewards = new global::Protobuf.Messages.GetAfkRewards();
           }
           GetAfkRewards.MergeFrom(other.GetAfkRewards);
           break;
         case RequestTypeOneofCase.ClaimAfkRewards:
-          if (ClaimAfkRewards == null) {
+          if (ClaimAfkRewards == null)
+          {
             ClaimAfkRewards = new global::Protobuf.Messages.ClaimAfkRewards();
           }
           ClaimAfkRewards.MergeFrom(other.ClaimAfkRewards);
           break;
         case RequestTypeOneofCase.GetUserSuperCampaignProgresses:
-          if (GetUserSuperCampaignProgresses == null) {
+          if (GetUserSuperCampaignProgresses == null)
+          {
             GetUserSuperCampaignProgresses = new global::Protobuf.Messages.GetUserSuperCampaignProgresses();
           }
           GetUserSuperCampaignProgresses.MergeFrom(other.GetUserSuperCampaignProgresses);
           break;
         case RequestTypeOneofCase.LevelUpKalineTree:
-          if (LevelUpKalineTree == null) {
+          if (LevelUpKalineTree == null)
+          {
             LevelUpKalineTree = new global::Protobuf.Messages.LevelUpKalineTree();
           }
           LevelUpKalineTree.MergeFrom(other.LevelUpKalineTree);
@@ -1210,10 +1355,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -1429,238 +1575,287 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            global::Protobuf.Messages.GetUser subBuilder = new global::Protobuf.Messages.GetUser();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetUser) {
-              subBuilder.MergeFrom(GetUser);
+          case 10:
+            {
+              global::Protobuf.Messages.GetUser subBuilder = new global::Protobuf.Messages.GetUser();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetUser)
+              {
+                subBuilder.MergeFrom(GetUser);
+              }
+              input.ReadMessage(subBuilder);
+              GetUser = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetUser = subBuilder;
-            break;
-          }
-          case 18: {
-            global::Protobuf.Messages.GetUserByUsername subBuilder = new global::Protobuf.Messages.GetUserByUsername();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername) {
-              subBuilder.MergeFrom(GetUserByUsername);
+          case 18:
+            {
+              global::Protobuf.Messages.GetUserByUsername subBuilder = new global::Protobuf.Messages.GetUserByUsername();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetUserByUsername)
+              {
+                subBuilder.MergeFrom(GetUserByUsername);
+              }
+              input.ReadMessage(subBuilder);
+              GetUserByUsername = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetUserByUsername = subBuilder;
-            break;
-          }
-          case 26: {
-            global::Protobuf.Messages.CreateUser subBuilder = new global::Protobuf.Messages.CreateUser();
-            if (requestTypeCase_ == RequestTypeOneofCase.CreateUser) {
-              subBuilder.MergeFrom(CreateUser);
+          case 26:
+            {
+              global::Protobuf.Messages.CreateUser subBuilder = new global::Protobuf.Messages.CreateUser();
+              if (requestTypeCase_ == RequestTypeOneofCase.CreateUser)
+              {
+                subBuilder.MergeFrom(CreateUser);
+              }
+              input.ReadMessage(subBuilder);
+              CreateUser = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            CreateUser = subBuilder;
-            break;
-          }
-          case 34: {
-            global::Protobuf.Messages.GetCampaigns subBuilder = new global::Protobuf.Messages.GetCampaigns();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetCampaigns) {
-              subBuilder.MergeFrom(GetCampaigns);
+          case 34:
+            {
+              global::Protobuf.Messages.GetCampaigns subBuilder = new global::Protobuf.Messages.GetCampaigns();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetCampaigns)
+              {
+                subBuilder.MergeFrom(GetCampaigns);
+              }
+              input.ReadMessage(subBuilder);
+              GetCampaigns = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetCampaigns = subBuilder;
-            break;
-          }
-          case 42: {
-            global::Protobuf.Messages.GetCampaign subBuilder = new global::Protobuf.Messages.GetCampaign();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetCampaign) {
-              subBuilder.MergeFrom(GetCampaign);
+          case 42:
+            {
+              global::Protobuf.Messages.GetCampaign subBuilder = new global::Protobuf.Messages.GetCampaign();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetCampaign)
+              {
+                subBuilder.MergeFrom(GetCampaign);
+              }
+              input.ReadMessage(subBuilder);
+              GetCampaign = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetCampaign = subBuilder;
-            break;
-          }
-          case 50: {
-            global::Protobuf.Messages.GetLevel subBuilder = new global::Protobuf.Messages.GetLevel();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetLevel) {
-              subBuilder.MergeFrom(GetLevel);
+          case 50:
+            {
+              global::Protobuf.Messages.GetLevel subBuilder = new global::Protobuf.Messages.GetLevel();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetLevel)
+              {
+                subBuilder.MergeFrom(GetLevel);
+              }
+              input.ReadMessage(subBuilder);
+              GetLevel = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetLevel = subBuilder;
-            break;
-          }
-          case 58: {
-            global::Protobuf.Messages.FightLevel subBuilder = new global::Protobuf.Messages.FightLevel();
-            if (requestTypeCase_ == RequestTypeOneofCase.FightLevel) {
-              subBuilder.MergeFrom(FightLevel);
+          case 58:
+            {
+              global::Protobuf.Messages.FightLevel subBuilder = new global::Protobuf.Messages.FightLevel();
+              if (requestTypeCase_ == RequestTypeOneofCase.FightLevel)
+              {
+                subBuilder.MergeFrom(FightLevel);
+              }
+              input.ReadMessage(subBuilder);
+              FightLevel = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            FightLevel = subBuilder;
-            break;
-          }
-          case 74: {
-            global::Protobuf.Messages.SelectUnit subBuilder = new global::Protobuf.Messages.SelectUnit();
-            if (requestTypeCase_ == RequestTypeOneofCase.SelectUnit) {
-              subBuilder.MergeFrom(SelectUnit);
+          case 74:
+            {
+              global::Protobuf.Messages.SelectUnit subBuilder = new global::Protobuf.Messages.SelectUnit();
+              if (requestTypeCase_ == RequestTypeOneofCase.SelectUnit)
+              {
+                subBuilder.MergeFrom(SelectUnit);
+              }
+              input.ReadMessage(subBuilder);
+              SelectUnit = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            SelectUnit = subBuilder;
-            break;
-          }
-          case 82: {
-            global::Protobuf.Messages.UnselectUnit subBuilder = new global::Protobuf.Messages.UnselectUnit();
-            if (requestTypeCase_ == RequestTypeOneofCase.UnselectUnit) {
-              subBuilder.MergeFrom(UnselectUnit);
+          case 82:
+            {
+              global::Protobuf.Messages.UnselectUnit subBuilder = new global::Protobuf.Messages.UnselectUnit();
+              if (requestTypeCase_ == RequestTypeOneofCase.UnselectUnit)
+              {
+                subBuilder.MergeFrom(UnselectUnit);
+              }
+              input.ReadMessage(subBuilder);
+              UnselectUnit = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            UnselectUnit = subBuilder;
-            break;
-          }
-          case 90: {
-            global::Protobuf.Messages.LevelUpUnit subBuilder = new global::Protobuf.Messages.LevelUpUnit();
-            if (requestTypeCase_ == RequestTypeOneofCase.LevelUpUnit) {
-              subBuilder.MergeFrom(LevelUpUnit);
+          case 90:
+            {
+              global::Protobuf.Messages.LevelUpUnit subBuilder = new global::Protobuf.Messages.LevelUpUnit();
+              if (requestTypeCase_ == RequestTypeOneofCase.LevelUpUnit)
+              {
+                subBuilder.MergeFrom(LevelUpUnit);
+              }
+              input.ReadMessage(subBuilder);
+              LevelUpUnit = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            LevelUpUnit = subBuilder;
-            break;
-          }
-          case 98: {
-            global::Protobuf.Messages.TierUpUnit subBuilder = new global::Protobuf.Messages.TierUpUnit();
-            if (requestTypeCase_ == RequestTypeOneofCase.TierUpUnit) {
-              subBuilder.MergeFrom(TierUpUnit);
+          case 98:
+            {
+              global::Protobuf.Messages.TierUpUnit subBuilder = new global::Protobuf.Messages.TierUpUnit();
+              if (requestTypeCase_ == RequestTypeOneofCase.TierUpUnit)
+              {
+                subBuilder.MergeFrom(TierUpUnit);
+              }
+              input.ReadMessage(subBuilder);
+              TierUpUnit = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            TierUpUnit = subBuilder;
-            break;
-          }
-          case 106: {
-            global::Protobuf.Messages.FuseUnit subBuilder = new global::Protobuf.Messages.FuseUnit();
-            if (requestTypeCase_ == RequestTypeOneofCase.FuseUnit) {
-              subBuilder.MergeFrom(FuseUnit);
+          case 106:
+            {
+              global::Protobuf.Messages.FuseUnit subBuilder = new global::Protobuf.Messages.FuseUnit();
+              if (requestTypeCase_ == RequestTypeOneofCase.FuseUnit)
+              {
+                subBuilder.MergeFrom(FuseUnit);
+              }
+              input.ReadMessage(subBuilder);
+              FuseUnit = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            FuseUnit = subBuilder;
-            break;
-          }
-          case 114: {
-            global::Protobuf.Messages.EquipItem subBuilder = new global::Protobuf.Messages.EquipItem();
-            if (requestTypeCase_ == RequestTypeOneofCase.EquipItem) {
-              subBuilder.MergeFrom(EquipItem);
+          case 114:
+            {
+              global::Protobuf.Messages.EquipItem subBuilder = new global::Protobuf.Messages.EquipItem();
+              if (requestTypeCase_ == RequestTypeOneofCase.EquipItem)
+              {
+                subBuilder.MergeFrom(EquipItem);
+              }
+              input.ReadMessage(subBuilder);
+              EquipItem = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            EquipItem = subBuilder;
-            break;
-          }
-          case 122: {
-            global::Protobuf.Messages.UnequipItem subBuilder = new global::Protobuf.Messages.UnequipItem();
-            if (requestTypeCase_ == RequestTypeOneofCase.UnequipItem) {
-              subBuilder.MergeFrom(UnequipItem);
+          case 122:
+            {
+              global::Protobuf.Messages.UnequipItem subBuilder = new global::Protobuf.Messages.UnequipItem();
+              if (requestTypeCase_ == RequestTypeOneofCase.UnequipItem)
+              {
+                subBuilder.MergeFrom(UnequipItem);
+              }
+              input.ReadMessage(subBuilder);
+              UnequipItem = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            UnequipItem = subBuilder;
-            break;
-          }
-          case 130: {
-            global::Protobuf.Messages.GetItem subBuilder = new global::Protobuf.Messages.GetItem();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetItem) {
-              subBuilder.MergeFrom(GetItem);
+          case 130:
+            {
+              global::Protobuf.Messages.GetItem subBuilder = new global::Protobuf.Messages.GetItem();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetItem)
+              {
+                subBuilder.MergeFrom(GetItem);
+              }
+              input.ReadMessage(subBuilder);
+              GetItem = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetItem = subBuilder;
-            break;
-          }
-          case 138: {
-            global::Protobuf.Messages.LevelUpItem subBuilder = new global::Protobuf.Messages.LevelUpItem();
-            if (requestTypeCase_ == RequestTypeOneofCase.LevelUpItem) {
-              subBuilder.MergeFrom(LevelUpItem);
+          case 138:
+            {
+              global::Protobuf.Messages.LevelUpItem subBuilder = new global::Protobuf.Messages.LevelUpItem();
+              if (requestTypeCase_ == RequestTypeOneofCase.LevelUpItem)
+              {
+                subBuilder.MergeFrom(LevelUpItem);
+              }
+              input.ReadMessage(subBuilder);
+              LevelUpItem = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            LevelUpItem = subBuilder;
-            break;
-          }
-          case 146: {
-            global::Protobuf.Messages.GetBoxes subBuilder = new global::Protobuf.Messages.GetBoxes();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetBoxes) {
-              subBuilder.MergeFrom(GetBoxes);
+          case 146:
+            {
+              global::Protobuf.Messages.GetBoxes subBuilder = new global::Protobuf.Messages.GetBoxes();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetBoxes)
+              {
+                subBuilder.MergeFrom(GetBoxes);
+              }
+              input.ReadMessage(subBuilder);
+              GetBoxes = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetBoxes = subBuilder;
-            break;
-          }
-          case 154: {
-            global::Protobuf.Messages.GetBox subBuilder = new global::Protobuf.Messages.GetBox();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetBox) {
-              subBuilder.MergeFrom(GetBox);
+          case 154:
+            {
+              global::Protobuf.Messages.GetBox subBuilder = new global::Protobuf.Messages.GetBox();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetBox)
+              {
+                subBuilder.MergeFrom(GetBox);
+              }
+              input.ReadMessage(subBuilder);
+              GetBox = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetBox = subBuilder;
-            break;
-          }
-          case 162: {
-            global::Protobuf.Messages.Summon subBuilder = new global::Protobuf.Messages.Summon();
-            if (requestTypeCase_ == RequestTypeOneofCase.Summon) {
-              subBuilder.MergeFrom(Summon);
+          case 162:
+            {
+              global::Protobuf.Messages.Summon subBuilder = new global::Protobuf.Messages.Summon();
+              if (requestTypeCase_ == RequestTypeOneofCase.Summon)
+              {
+                subBuilder.MergeFrom(Summon);
+              }
+              input.ReadMessage(subBuilder);
+              Summon = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Summon = subBuilder;
-            break;
-          }
-          case 170: {
-            global::Protobuf.Messages.GetAfkRewards subBuilder = new global::Protobuf.Messages.GetAfkRewards();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetAfkRewards) {
-              subBuilder.MergeFrom(GetAfkRewards);
+          case 170:
+            {
+              global::Protobuf.Messages.GetAfkRewards subBuilder = new global::Protobuf.Messages.GetAfkRewards();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetAfkRewards)
+              {
+                subBuilder.MergeFrom(GetAfkRewards);
+              }
+              input.ReadMessage(subBuilder);
+              GetAfkRewards = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetAfkRewards = subBuilder;
-            break;
-          }
-          case 178: {
-            global::Protobuf.Messages.ClaimAfkRewards subBuilder = new global::Protobuf.Messages.ClaimAfkRewards();
-            if (requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards) {
-              subBuilder.MergeFrom(ClaimAfkRewards);
+          case 178:
+            {
+              global::Protobuf.Messages.ClaimAfkRewards subBuilder = new global::Protobuf.Messages.ClaimAfkRewards();
+              if (requestTypeCase_ == RequestTypeOneofCase.ClaimAfkRewards)
+              {
+                subBuilder.MergeFrom(ClaimAfkRewards);
+              }
+              input.ReadMessage(subBuilder);
+              ClaimAfkRewards = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            ClaimAfkRewards = subBuilder;
-            break;
-          }
-          case 186: {
-            global::Protobuf.Messages.GetUserSuperCampaignProgresses subBuilder = new global::Protobuf.Messages.GetUserSuperCampaignProgresses();
-            if (requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses) {
-              subBuilder.MergeFrom(GetUserSuperCampaignProgresses);
+          case 186:
+            {
+              global::Protobuf.Messages.GetUserSuperCampaignProgresses subBuilder = new global::Protobuf.Messages.GetUserSuperCampaignProgresses();
+              if (requestTypeCase_ == RequestTypeOneofCase.GetUserSuperCampaignProgresses)
+              {
+                subBuilder.MergeFrom(GetUserSuperCampaignProgresses);
+              }
+              input.ReadMessage(subBuilder);
+              GetUserSuperCampaignProgresses = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            GetUserSuperCampaignProgresses = subBuilder;
-            break;
-          }
-          case 194: {
-            global::Protobuf.Messages.LevelUpKalineTree subBuilder = new global::Protobuf.Messages.LevelUpKalineTree();
-            if (requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree) {
-              subBuilder.MergeFrom(LevelUpKalineTree);
+          case 194:
+            {
+              global::Protobuf.Messages.LevelUpKalineTree subBuilder = new global::Protobuf.Messages.LevelUpKalineTree();
+              if (requestTypeCase_ == RequestTypeOneofCase.LevelUpKalineTree)
+              {
+                subBuilder.MergeFrom(LevelUpKalineTree);
+              }
+              input.ReadMessage(subBuilder);
+              LevelUpKalineTree = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            LevelUpKalineTree = subBuilder;
-            break;
-          }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetUser : pb::IMessage<GetUser>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetUser> _parser = new pb::MessageParser<GetUser>(() => new GetUser());
     private pb::UnknownFieldSet _unknownFields;
@@ -1670,19 +1865,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[1]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUser() {
+    public GetUser()
+    {
       OnConstruction();
     }
 
@@ -1690,14 +1888,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUser(GetUser other) : this() {
+    public GetUser(GetUser other) : this()
+    {
       userId_ = other.userId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUser Clone() {
+    public GetUser Clone()
+    {
       return new GetUser(this);
     }
 
@@ -1706,26 +1906,32 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetUser);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetUser other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetUser other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -1734,10 +1940,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -1745,16 +1953,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -1762,31 +1972,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -1794,11 +2010,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetUser other) {
-      if (other == null) {
+    public void MergeFrom(GetUser other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -1806,10 +2025,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -1822,35 +2042,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetUserByUsername : pb::IMessage<GetUserByUsername>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetUserByUsername> _parser = new pb::MessageParser<GetUserByUsername>(() => new GetUserByUsername());
     private pb::UnknownFieldSet _unknownFields;
@@ -1860,19 +2084,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[2]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUserByUsername() {
+    public GetUserByUsername()
+    {
       OnConstruction();
     }
 
@@ -1880,14 +2107,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUserByUsername(GetUserByUsername other) : this() {
+    public GetUserByUsername(GetUserByUsername other) : this()
+    {
       username_ = other.username_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUserByUsername Clone() {
+    public GetUserByUsername Clone()
+    {
       return new GetUserByUsername(this);
     }
 
@@ -1896,26 +2125,32 @@ namespace Protobuf.Messages {
     private string username_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Username {
+    public string Username
+    {
       get { return username_; }
-      set {
+      set
+      {
         username_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetUserByUsername);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetUserByUsername other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetUserByUsername other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Username != other.Username) return false;
@@ -1924,10 +2159,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Username.Length != 0) hash ^= Username.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -1935,16 +2172,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Username.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Username);
@@ -1952,31 +2191,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Username.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Username.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Username);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Username.Length != 0) {
+      if (Username.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Username);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -1984,11 +2229,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetUserByUsername other) {
-      if (other == null) {
+    public void MergeFrom(GetUserByUsername other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Username.Length != 0) {
+      if (other.Username.Length != 0)
+      {
         Username = other.Username;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -1996,10 +2244,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -2012,35 +2261,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Username = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              Username = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CreateUser : pb::IMessage<CreateUser>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<CreateUser> _parser = new pb::MessageParser<CreateUser>(() => new CreateUser());
     private pb::UnknownFieldSet _unknownFields;
@@ -2050,19 +2303,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[3]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CreateUser() {
+    public CreateUser()
+    {
       OnConstruction();
     }
 
@@ -2070,14 +2326,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CreateUser(CreateUser other) : this() {
+    public CreateUser(CreateUser other) : this()
+    {
       username_ = other.username_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CreateUser Clone() {
+    public CreateUser Clone()
+    {
       return new CreateUser(this);
     }
 
@@ -2086,26 +2344,32 @@ namespace Protobuf.Messages {
     private string username_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Username {
+    public string Username
+    {
       get { return username_; }
-      set {
+      set
+      {
         username_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as CreateUser);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(CreateUser other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(CreateUser other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Username != other.Username) return false;
@@ -2114,10 +2378,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Username.Length != 0) hash ^= Username.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -2125,16 +2391,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Username.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Username);
@@ -2142,31 +2410,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Username.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Username.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Username);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Username.Length != 0) {
+      if (Username.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Username);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -2174,11 +2448,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(CreateUser other) {
-      if (other == null) {
+    public void MergeFrom(CreateUser other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Username.Length != 0) {
+      if (other.Username.Length != 0)
+      {
         Username = other.Username;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -2186,10 +2463,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -2202,35 +2480,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Username = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              Username = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetCampaigns : pb::IMessage<GetCampaigns>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetCampaigns> _parser = new pb::MessageParser<GetCampaigns>(() => new GetCampaigns());
     private pb::UnknownFieldSet _unknownFields;
@@ -2240,19 +2522,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[4]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetCampaigns() {
+    public GetCampaigns()
+    {
       OnConstruction();
     }
 
@@ -2260,14 +2545,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetCampaigns(GetCampaigns other) : this() {
+    public GetCampaigns(GetCampaigns other) : this()
+    {
       userId_ = other.userId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetCampaigns Clone() {
+    public GetCampaigns Clone()
+    {
       return new GetCampaigns(this);
     }
 
@@ -2276,26 +2563,32 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetCampaigns);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetCampaigns other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetCampaigns other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -2304,10 +2597,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -2315,16 +2610,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -2332,31 +2629,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -2364,11 +2667,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetCampaigns other) {
-      if (other == null) {
+    public void MergeFrom(GetCampaigns other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -2376,10 +2682,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -2392,35 +2699,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetCampaign : pb::IMessage<GetCampaign>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetCampaign> _parser = new pb::MessageParser<GetCampaign>(() => new GetCampaign());
     private pb::UnknownFieldSet _unknownFields;
@@ -2430,19 +2741,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[5]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetCampaign() {
+    public GetCampaign()
+    {
       OnConstruction();
     }
 
@@ -2450,7 +2764,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetCampaign(GetCampaign other) : this() {
+    public GetCampaign(GetCampaign other) : this()
+    {
       userId_ = other.userId_;
       campaignId_ = other.campaignId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -2458,7 +2773,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetCampaign Clone() {
+    public GetCampaign Clone()
+    {
       return new GetCampaign(this);
     }
 
@@ -2467,9 +2783,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -2479,26 +2797,32 @@ namespace Protobuf.Messages {
     private string campaignId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string CampaignId {
+    public string CampaignId
+    {
       get { return campaignId_; }
-      set {
+      set
+      {
         campaignId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetCampaign);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetCampaign other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetCampaign other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -2508,11 +2832,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (CampaignId.Length != 0) hash ^= CampaignId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -2520,16 +2846,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -2541,38 +2869,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (CampaignId.Length != 0) {
+      if (CampaignId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(CampaignId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (CampaignId.Length != 0) {
+      if (CampaignId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(CampaignId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -2580,14 +2916,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetCampaign other) {
-      if (other == null) {
+    public void MergeFrom(GetCampaign other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.CampaignId.Length != 0) {
+      if (other.CampaignId.Length != 0)
+      {
         CampaignId = other.CampaignId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -2595,10 +2935,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -2615,39 +2956,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            CampaignId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              CampaignId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetLevel : pb::IMessage<GetLevel>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetLevel> _parser = new pb::MessageParser<GetLevel>(() => new GetLevel());
     private pb::UnknownFieldSet _unknownFields;
@@ -2657,19 +3003,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[6]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetLevel() {
+    public GetLevel()
+    {
       OnConstruction();
     }
 
@@ -2677,7 +3026,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetLevel(GetLevel other) : this() {
+    public GetLevel(GetLevel other) : this()
+    {
       userId_ = other.userId_;
       levelId_ = other.levelId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -2685,7 +3035,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetLevel Clone() {
+    public GetLevel Clone()
+    {
       return new GetLevel(this);
     }
 
@@ -2694,9 +3045,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -2706,26 +3059,32 @@ namespace Protobuf.Messages {
     private string levelId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string LevelId {
+    public string LevelId
+    {
       get { return levelId_; }
-      set {
+      set
+      {
         levelId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetLevel);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetLevel other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetLevel other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -2735,11 +3094,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (LevelId.Length != 0) hash ^= LevelId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -2747,16 +3108,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -2768,38 +3131,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (LevelId.Length != 0) {
+      if (LevelId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(LevelId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (LevelId.Length != 0) {
+      if (LevelId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(LevelId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -2807,14 +3178,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetLevel other) {
-      if (other == null) {
+    public void MergeFrom(GetLevel other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.LevelId.Length != 0) {
+      if (other.LevelId.Length != 0)
+      {
         LevelId = other.LevelId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -2822,10 +3197,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -2842,39 +3218,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            LevelId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              LevelId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class FightLevel : pb::IMessage<FightLevel>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<FightLevel> _parser = new pb::MessageParser<FightLevel>(() => new FightLevel());
     private pb::UnknownFieldSet _unknownFields;
@@ -2884,19 +3265,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[7]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public FightLevel() {
+    public FightLevel()
+    {
       OnConstruction();
     }
 
@@ -2904,7 +3288,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public FightLevel(FightLevel other) : this() {
+    public FightLevel(FightLevel other) : this()
+    {
       userId_ = other.userId_;
       levelId_ = other.levelId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -2912,7 +3297,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public FightLevel Clone() {
+    public FightLevel Clone()
+    {
       return new FightLevel(this);
     }
 
@@ -2921,9 +3307,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -2933,26 +3321,32 @@ namespace Protobuf.Messages {
     private string levelId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string LevelId {
+    public string LevelId
+    {
       get { return levelId_; }
-      set {
+      set
+      {
         levelId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as FightLevel);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(FightLevel other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(FightLevel other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -2962,11 +3356,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (LevelId.Length != 0) hash ^= LevelId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -2974,16 +3370,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -2995,38 +3393,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (LevelId.Length != 0) {
+      if (LevelId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(LevelId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (LevelId.Length != 0) {
+      if (LevelId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(LevelId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -3034,14 +3440,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(FightLevel other) {
-      if (other == null) {
+    public void MergeFrom(FightLevel other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.LevelId.Length != 0) {
+      if (other.LevelId.Length != 0)
+      {
         LevelId = other.LevelId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -3049,10 +3459,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -3069,39 +3480,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            LevelId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              LevelId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SelectUnit : pb::IMessage<SelectUnit>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<SelectUnit> _parser = new pb::MessageParser<SelectUnit>(() => new SelectUnit());
     private pb::UnknownFieldSet _unknownFields;
@@ -3111,19 +3527,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[8]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SelectUnit() {
+    public SelectUnit()
+    {
       OnConstruction();
     }
 
@@ -3131,7 +3550,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SelectUnit(SelectUnit other) : this() {
+    public SelectUnit(SelectUnit other) : this()
+    {
       userId_ = other.userId_;
       unitId_ = other.unitId_;
       slot_ = other.slot_;
@@ -3140,7 +3560,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SelectUnit Clone() {
+    public SelectUnit Clone()
+    {
       return new SelectUnit(this);
     }
 
@@ -3149,9 +3570,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -3161,9 +3584,11 @@ namespace Protobuf.Messages {
     private string unitId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UnitId {
+    public string UnitId
+    {
       get { return unitId_; }
-      set {
+      set
+      {
         unitId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -3173,26 +3598,32 @@ namespace Protobuf.Messages {
     private uint slot_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint Slot {
+    public uint Slot
+    {
       get { return slot_; }
-      set {
+      set
+      {
         slot_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as SelectUnit);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(SelectUnit other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(SelectUnit other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -3203,12 +3634,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (UnitId.Length != 0) hash ^= UnitId.GetHashCode();
       if (Slot != 0) hash ^= Slot.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -3216,16 +3649,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -3241,45 +3676,55 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(UnitId);
       }
-      if (Slot != 0) {
+      if (Slot != 0)
+      {
         output.WriteRawTag(24);
         output.WriteUInt32(Slot);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UnitId);
       }
-      if (Slot != 0) {
+      if (Slot != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Slot);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -3287,17 +3732,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(SelectUnit other) {
-      if (other == null) {
+    public void MergeFrom(SelectUnit other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.UnitId.Length != 0) {
+      if (other.UnitId.Length != 0)
+      {
         UnitId = other.UnitId;
       }
-      if (other.Slot != 0) {
+      if (other.Slot != 0)
+      {
         Slot = other.Slot;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -3305,10 +3755,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -3329,43 +3780,49 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            UnitId = input.ReadString();
-            break;
-          }
-          case 24: {
-            Slot = input.ReadUInt32();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              UnitId = input.ReadString();
+              break;
+            }
+          case 24:
+            {
+              Slot = input.ReadUInt32();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UnselectUnit : pb::IMessage<UnselectUnit>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<UnselectUnit> _parser = new pb::MessageParser<UnselectUnit>(() => new UnselectUnit());
     private pb::UnknownFieldSet _unknownFields;
@@ -3375,19 +3832,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[9]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnselectUnit() {
+    public UnselectUnit()
+    {
       OnConstruction();
     }
 
@@ -3395,7 +3855,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnselectUnit(UnselectUnit other) : this() {
+    public UnselectUnit(UnselectUnit other) : this()
+    {
       userId_ = other.userId_;
       unitId_ = other.unitId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -3403,7 +3864,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnselectUnit Clone() {
+    public UnselectUnit Clone()
+    {
       return new UnselectUnit(this);
     }
 
@@ -3412,9 +3874,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -3424,26 +3888,32 @@ namespace Protobuf.Messages {
     private string unitId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UnitId {
+    public string UnitId
+    {
       get { return unitId_; }
-      set {
+      set
+      {
         unitId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as UnselectUnit);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(UnselectUnit other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(UnselectUnit other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -3453,11 +3923,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (UnitId.Length != 0) hash ^= UnitId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -3465,16 +3937,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -3486,38 +3960,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -3525,14 +4007,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(UnselectUnit other) {
-      if (other == null) {
+    public void MergeFrom(UnselectUnit other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.UnitId.Length != 0) {
+      if (other.UnitId.Length != 0)
+      {
         UnitId = other.UnitId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -3540,10 +4026,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -3560,39 +4047,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            UnitId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              UnitId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LevelUpUnit : pb::IMessage<LevelUpUnit>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<LevelUpUnit> _parser = new pb::MessageParser<LevelUpUnit>(() => new LevelUpUnit());
     private pb::UnknownFieldSet _unknownFields;
@@ -3602,19 +4094,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[10]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpUnit() {
+    public LevelUpUnit()
+    {
       OnConstruction();
     }
 
@@ -3622,7 +4117,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpUnit(LevelUpUnit other) : this() {
+    public LevelUpUnit(LevelUpUnit other) : this()
+    {
       userId_ = other.userId_;
       unitId_ = other.unitId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -3630,7 +4126,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpUnit Clone() {
+    public LevelUpUnit Clone()
+    {
       return new LevelUpUnit(this);
     }
 
@@ -3639,9 +4136,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -3651,26 +4150,32 @@ namespace Protobuf.Messages {
     private string unitId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UnitId {
+    public string UnitId
+    {
       get { return unitId_; }
-      set {
+      set
+      {
         unitId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as LevelUpUnit);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(LevelUpUnit other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(LevelUpUnit other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -3680,11 +4185,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (UnitId.Length != 0) hash ^= UnitId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -3692,16 +4199,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -3713,38 +4222,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -3752,14 +4269,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(LevelUpUnit other) {
-      if (other == null) {
+    public void MergeFrom(LevelUpUnit other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.UnitId.Length != 0) {
+      if (other.UnitId.Length != 0)
+      {
         UnitId = other.UnitId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -3767,10 +4288,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -3787,39 +4309,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            UnitId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              UnitId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class TierUpUnit : pb::IMessage<TierUpUnit>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<TierUpUnit> _parser = new pb::MessageParser<TierUpUnit>(() => new TierUpUnit());
     private pb::UnknownFieldSet _unknownFields;
@@ -3829,19 +4356,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[11]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TierUpUnit() {
+    public TierUpUnit()
+    {
       OnConstruction();
     }
 
@@ -3849,7 +4379,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TierUpUnit(TierUpUnit other) : this() {
+    public TierUpUnit(TierUpUnit other) : this()
+    {
       userId_ = other.userId_;
       unitId_ = other.unitId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -3857,7 +4388,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TierUpUnit Clone() {
+    public TierUpUnit Clone()
+    {
       return new TierUpUnit(this);
     }
 
@@ -3866,9 +4398,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -3878,26 +4412,32 @@ namespace Protobuf.Messages {
     private string unitId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UnitId {
+    public string UnitId
+    {
       get { return unitId_; }
-      set {
+      set
+      {
         unitId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as TierUpUnit);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(TierUpUnit other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(TierUpUnit other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -3907,11 +4447,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (UnitId.Length != 0) hash ^= UnitId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -3919,16 +4461,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -3940,38 +4484,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -3979,14 +4531,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(TierUpUnit other) {
-      if (other == null) {
+    public void MergeFrom(TierUpUnit other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.UnitId.Length != 0) {
+      if (other.UnitId.Length != 0)
+      {
         UnitId = other.UnitId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -3994,10 +4550,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -4014,39 +4571,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            UnitId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              UnitId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class FuseUnit : pb::IMessage<FuseUnit>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<FuseUnit> _parser = new pb::MessageParser<FuseUnit>(() => new FuseUnit());
     private pb::UnknownFieldSet _unknownFields;
@@ -4056,19 +4618,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[12]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public FuseUnit() {
+    public FuseUnit()
+    {
       OnConstruction();
     }
 
@@ -4076,7 +4641,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public FuseUnit(FuseUnit other) : this() {
+    public FuseUnit(FuseUnit other) : this()
+    {
       userId_ = other.userId_;
       unitId_ = other.unitId_;
       consumedUnitsIds_ = other.consumedUnitsIds_.Clone();
@@ -4085,7 +4651,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public FuseUnit Clone() {
+    public FuseUnit Clone()
+    {
       return new FuseUnit(this);
     }
 
@@ -4094,9 +4661,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -4106,9 +4675,11 @@ namespace Protobuf.Messages {
     private string unitId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UnitId {
+    public string UnitId
+    {
       get { return unitId_; }
-      set {
+      set
+      {
         unitId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -4120,39 +4691,46 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<string> consumedUnitsIds_ = new pbc::RepeatedField<string>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<string> ConsumedUnitsIds {
+    public pbc::RepeatedField<string> ConsumedUnitsIds
+    {
       get { return consumedUnitsIds_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as FuseUnit);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(FuseUnit other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(FuseUnit other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
       if (UnitId != other.UnitId) return false;
-      if(!consumedUnitsIds_.Equals(other.consumedUnitsIds_)) return false;
+      if (!consumedUnitsIds_.Equals(other.consumedUnitsIds_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (UnitId.Length != 0) hash ^= UnitId.GetHashCode();
       hash ^= consumedUnitsIds_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -4160,16 +4738,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -4182,40 +4762,48 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(UnitId);
       }
       consumedUnitsIds_.WriteTo(ref output, _repeated_consumedUnitsIds_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UnitId);
       }
       size += consumedUnitsIds_.CalculateSize(_repeated_consumedUnitsIds_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -4223,14 +4811,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(FuseUnit other) {
-      if (other == null) {
+    public void MergeFrom(FuseUnit other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.UnitId.Length != 0) {
+      if (other.UnitId.Length != 0)
+      {
         UnitId = other.UnitId;
       }
       consumedUnitsIds_.Add(other.consumedUnitsIds_);
@@ -4239,10 +4831,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -4263,43 +4856,49 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            UnitId = input.ReadString();
-            break;
-          }
-          case 26: {
-            consumedUnitsIds_.AddEntriesFrom(ref input, _repeated_consumedUnitsIds_codec);
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              UnitId = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              consumedUnitsIds_.AddEntriesFrom(ref input, _repeated_consumedUnitsIds_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class EquipItem : pb::IMessage<EquipItem>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<EquipItem> _parser = new pb::MessageParser<EquipItem>(() => new EquipItem());
     private pb::UnknownFieldSet _unknownFields;
@@ -4309,19 +4908,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[13]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public EquipItem() {
+    public EquipItem()
+    {
       OnConstruction();
     }
 
@@ -4329,7 +4931,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public EquipItem(EquipItem other) : this() {
+    public EquipItem(EquipItem other) : this()
+    {
       userId_ = other.userId_;
       itemId_ = other.itemId_;
       unitId_ = other.unitId_;
@@ -4338,7 +4941,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public EquipItem Clone() {
+    public EquipItem Clone()
+    {
       return new EquipItem(this);
     }
 
@@ -4347,9 +4951,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -4359,9 +4965,11 @@ namespace Protobuf.Messages {
     private string itemId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string ItemId {
+    public string ItemId
+    {
       get { return itemId_; }
-      set {
+      set
+      {
         itemId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -4371,26 +4979,32 @@ namespace Protobuf.Messages {
     private string unitId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UnitId {
+    public string UnitId
+    {
       get { return unitId_; }
-      set {
+      set
+      {
         unitId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as EquipItem);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(EquipItem other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(EquipItem other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -4401,12 +5015,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (ItemId.Length != 0) hash ^= ItemId.GetHashCode();
       if (UnitId.Length != 0) hash ^= UnitId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -4414,16 +5030,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -4439,45 +5057,55 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (ItemId.Length != 0) {
+      if (ItemId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(ItemId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (ItemId.Length != 0) {
+      if (ItemId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(ItemId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -4485,17 +5113,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(EquipItem other) {
-      if (other == null) {
+    public void MergeFrom(EquipItem other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.ItemId.Length != 0) {
+      if (other.ItemId.Length != 0)
+      {
         ItemId = other.ItemId;
       }
-      if (other.UnitId.Length != 0) {
+      if (other.UnitId.Length != 0)
+      {
         UnitId = other.UnitId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -4503,10 +5136,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -4527,43 +5161,49 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            ItemId = input.ReadString();
-            break;
-          }
-          case 26: {
-            UnitId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              ItemId = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              UnitId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UnequipItem : pb::IMessage<UnequipItem>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<UnequipItem> _parser = new pb::MessageParser<UnequipItem>(() => new UnequipItem());
     private pb::UnknownFieldSet _unknownFields;
@@ -4573,19 +5213,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[14]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnequipItem() {
+    public UnequipItem()
+    {
       OnConstruction();
     }
 
@@ -4593,7 +5236,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnequipItem(UnequipItem other) : this() {
+    public UnequipItem(UnequipItem other) : this()
+    {
       userId_ = other.userId_;
       itemId_ = other.itemId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -4601,7 +5245,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnequipItem Clone() {
+    public UnequipItem Clone()
+    {
       return new UnequipItem(this);
     }
 
@@ -4610,9 +5255,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -4622,26 +5269,32 @@ namespace Protobuf.Messages {
     private string itemId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string ItemId {
+    public string ItemId
+    {
       get { return itemId_; }
-      set {
+      set
+      {
         itemId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as UnequipItem);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(UnequipItem other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(UnequipItem other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -4651,11 +5304,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (ItemId.Length != 0) hash ^= ItemId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -4663,16 +5318,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -4684,38 +5341,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (ItemId.Length != 0) {
+      if (ItemId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(ItemId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (ItemId.Length != 0) {
+      if (ItemId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(ItemId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -4723,14 +5388,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(UnequipItem other) {
-      if (other == null) {
+    public void MergeFrom(UnequipItem other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.ItemId.Length != 0) {
+      if (other.ItemId.Length != 0)
+      {
         ItemId = other.ItemId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -4738,10 +5407,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -4758,39 +5428,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            ItemId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              ItemId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetItem : pb::IMessage<GetItem>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetItem> _parser = new pb::MessageParser<GetItem>(() => new GetItem());
     private pb::UnknownFieldSet _unknownFields;
@@ -4800,19 +5475,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[15]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetItem() {
+    public GetItem()
+    {
       OnConstruction();
     }
 
@@ -4820,7 +5498,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetItem(GetItem other) : this() {
+    public GetItem(GetItem other) : this()
+    {
       userId_ = other.userId_;
       itemId_ = other.itemId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -4828,7 +5507,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetItem Clone() {
+    public GetItem Clone()
+    {
       return new GetItem(this);
     }
 
@@ -4837,9 +5517,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -4849,26 +5531,32 @@ namespace Protobuf.Messages {
     private string itemId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string ItemId {
+    public string ItemId
+    {
       get { return itemId_; }
-      set {
+      set
+      {
         itemId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetItem);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetItem other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetItem other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -4878,11 +5566,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (ItemId.Length != 0) hash ^= ItemId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -4890,16 +5580,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -4911,38 +5603,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (ItemId.Length != 0) {
+      if (ItemId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(ItemId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (ItemId.Length != 0) {
+      if (ItemId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(ItemId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -4950,14 +5650,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetItem other) {
-      if (other == null) {
+    public void MergeFrom(GetItem other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.ItemId.Length != 0) {
+      if (other.ItemId.Length != 0)
+      {
         ItemId = other.ItemId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -4965,10 +5669,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -4985,39 +5690,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            ItemId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              ItemId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LevelUpItem : pb::IMessage<LevelUpItem>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<LevelUpItem> _parser = new pb::MessageParser<LevelUpItem>(() => new LevelUpItem());
     private pb::UnknownFieldSet _unknownFields;
@@ -5027,19 +5737,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[16]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpItem() {
+    public LevelUpItem()
+    {
       OnConstruction();
     }
 
@@ -5047,7 +5760,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpItem(LevelUpItem other) : this() {
+    public LevelUpItem(LevelUpItem other) : this()
+    {
       userId_ = other.userId_;
       itemId_ = other.itemId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -5055,7 +5769,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpItem Clone() {
+    public LevelUpItem Clone()
+    {
       return new LevelUpItem(this);
     }
 
@@ -5064,9 +5779,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -5076,26 +5793,32 @@ namespace Protobuf.Messages {
     private string itemId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string ItemId {
+    public string ItemId
+    {
       get { return itemId_; }
-      set {
+      set
+      {
         itemId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as LevelUpItem);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(LevelUpItem other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(LevelUpItem other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -5105,11 +5828,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (ItemId.Length != 0) hash ^= ItemId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -5117,16 +5842,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -5138,38 +5865,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (ItemId.Length != 0) {
+      if (ItemId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(ItemId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (ItemId.Length != 0) {
+      if (ItemId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(ItemId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -5177,14 +5912,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(LevelUpItem other) {
-      if (other == null) {
+    public void MergeFrom(LevelUpItem other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.ItemId.Length != 0) {
+      if (other.ItemId.Length != 0)
+      {
         ItemId = other.ItemId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -5192,10 +5931,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -5212,39 +5952,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            ItemId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              ItemId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetAfkRewards : pb::IMessage<GetAfkRewards>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetAfkRewards> _parser = new pb::MessageParser<GetAfkRewards>(() => new GetAfkRewards());
     private pb::UnknownFieldSet _unknownFields;
@@ -5254,19 +5999,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[17]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetAfkRewards() {
+    public GetAfkRewards()
+    {
       OnConstruction();
     }
 
@@ -5274,14 +6022,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetAfkRewards(GetAfkRewards other) : this() {
+    public GetAfkRewards(GetAfkRewards other) : this()
+    {
       userId_ = other.userId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetAfkRewards Clone() {
+    public GetAfkRewards Clone()
+    {
       return new GetAfkRewards(this);
     }
 
@@ -5290,26 +6040,32 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetAfkRewards);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetAfkRewards other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetAfkRewards other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -5318,10 +6074,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -5329,16 +6087,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -5346,31 +6106,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -5378,11 +6144,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetAfkRewards other) {
-      if (other == null) {
+    public void MergeFrom(GetAfkRewards other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -5390,10 +6159,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -5406,35 +6176,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ClaimAfkRewards : pb::IMessage<ClaimAfkRewards>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<ClaimAfkRewards> _parser = new pb::MessageParser<ClaimAfkRewards>(() => new ClaimAfkRewards());
     private pb::UnknownFieldSet _unknownFields;
@@ -5444,19 +6218,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[18]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ClaimAfkRewards() {
+    public ClaimAfkRewards()
+    {
       OnConstruction();
     }
 
@@ -5464,14 +6241,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ClaimAfkRewards(ClaimAfkRewards other) : this() {
+    public ClaimAfkRewards(ClaimAfkRewards other) : this()
+    {
       userId_ = other.userId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ClaimAfkRewards Clone() {
+    public ClaimAfkRewards Clone()
+    {
       return new ClaimAfkRewards(this);
     }
 
@@ -5480,26 +6259,32 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as ClaimAfkRewards);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(ClaimAfkRewards other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(ClaimAfkRewards other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -5508,10 +6293,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -5519,16 +6306,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -5536,31 +6325,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -5568,11 +6363,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(ClaimAfkRewards other) {
-      if (other == null) {
+    public void MergeFrom(ClaimAfkRewards other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -5580,10 +6378,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -5596,35 +6395,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetBoxes : pb::IMessage<GetBoxes>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetBoxes> _parser = new pb::MessageParser<GetBoxes>(() => new GetBoxes());
     private pb::UnknownFieldSet _unknownFields;
@@ -5634,19 +6437,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[19]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetBoxes() {
+    public GetBoxes()
+    {
       OnConstruction();
     }
 
@@ -5654,14 +6460,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetBoxes(GetBoxes other) : this() {
+    public GetBoxes(GetBoxes other) : this()
+    {
       userId_ = other.userId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetBoxes Clone() {
+    public GetBoxes Clone()
+    {
       return new GetBoxes(this);
     }
 
@@ -5670,26 +6478,32 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetBoxes);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetBoxes other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetBoxes other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -5698,10 +6512,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -5709,16 +6525,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -5726,31 +6544,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -5758,11 +6582,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetBoxes other) {
-      if (other == null) {
+    public void MergeFrom(GetBoxes other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -5770,10 +6597,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -5786,35 +6614,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetBox : pb::IMessage<GetBox>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetBox> _parser = new pb::MessageParser<GetBox>(() => new GetBox());
     private pb::UnknownFieldSet _unknownFields;
@@ -5824,19 +6656,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[20]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetBox() {
+    public GetBox()
+    {
       OnConstruction();
     }
 
@@ -5844,14 +6679,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetBox(GetBox other) : this() {
+    public GetBox(GetBox other) : this()
+    {
       boxId_ = other.boxId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetBox Clone() {
+    public GetBox Clone()
+    {
       return new GetBox(this);
     }
 
@@ -5860,26 +6697,32 @@ namespace Protobuf.Messages {
     private string boxId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string BoxId {
+    public string BoxId
+    {
       get { return boxId_; }
-      set {
+      set
+      {
         boxId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetBox);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetBox other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetBox other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (BoxId != other.BoxId) return false;
@@ -5888,10 +6731,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (BoxId.Length != 0) hash ^= BoxId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -5899,16 +6744,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (BoxId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(BoxId);
@@ -5916,31 +6763,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (BoxId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (BoxId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(BoxId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (BoxId.Length != 0) {
+      if (BoxId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(BoxId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -5948,11 +6801,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetBox other) {
-      if (other == null) {
+    public void MergeFrom(GetBox other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.BoxId.Length != 0) {
+      if (other.BoxId.Length != 0)
+      {
         BoxId = other.BoxId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -5960,10 +6816,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -5976,35 +6833,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            BoxId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              BoxId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Summon : pb::IMessage<Summon>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Summon> _parser = new pb::MessageParser<Summon>(() => new Summon());
     private pb::UnknownFieldSet _unknownFields;
@@ -6014,19 +6875,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[21]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Summon() {
+    public Summon()
+    {
       OnConstruction();
     }
 
@@ -6034,7 +6898,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Summon(Summon other) : this() {
+    public Summon(Summon other) : this()
+    {
       userId_ = other.userId_;
       boxId_ = other.boxId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -6042,7 +6907,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Summon Clone() {
+    public Summon Clone()
+    {
       return new Summon(this);
     }
 
@@ -6051,9 +6917,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -6063,26 +6931,32 @@ namespace Protobuf.Messages {
     private string boxId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string BoxId {
+    public string BoxId
+    {
       get { return boxId_; }
-      set {
+      set
+      {
         boxId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Summon);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Summon other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Summon other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -6092,11 +6966,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (BoxId.Length != 0) hash ^= BoxId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -6104,16 +6980,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -6125,38 +7003,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (BoxId.Length != 0) {
+      if (BoxId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(BoxId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (BoxId.Length != 0) {
+      if (BoxId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(BoxId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -6164,14 +7050,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Summon other) {
-      if (other == null) {
+    public void MergeFrom(Summon other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.BoxId.Length != 0) {
+      if (other.BoxId.Length != 0)
+      {
         BoxId = other.BoxId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -6179,10 +7069,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -6199,39 +7090,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            BoxId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              BoxId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class GetUserSuperCampaignProgresses : pb::IMessage<GetUserSuperCampaignProgresses>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<GetUserSuperCampaignProgresses> _parser = new pb::MessageParser<GetUserSuperCampaignProgresses>(() => new GetUserSuperCampaignProgresses());
     private pb::UnknownFieldSet _unknownFields;
@@ -6241,19 +7137,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[22]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUserSuperCampaignProgresses() {
+    public GetUserSuperCampaignProgresses()
+    {
       OnConstruction();
     }
 
@@ -6261,14 +7160,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUserSuperCampaignProgresses(GetUserSuperCampaignProgresses other) : this() {
+    public GetUserSuperCampaignProgresses(GetUserSuperCampaignProgresses other) : this()
+    {
       userId_ = other.userId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public GetUserSuperCampaignProgresses Clone() {
+    public GetUserSuperCampaignProgresses Clone()
+    {
       return new GetUserSuperCampaignProgresses(this);
     }
 
@@ -6277,26 +7178,32 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as GetUserSuperCampaignProgresses);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(GetUserSuperCampaignProgresses other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(GetUserSuperCampaignProgresses other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -6305,10 +7212,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -6316,16 +7225,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -6333,31 +7244,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -6365,11 +7282,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(GetUserSuperCampaignProgresses other) {
-      if (other == null) {
+    public void MergeFrom(GetUserSuperCampaignProgresses other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -6377,10 +7297,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -6393,35 +7314,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LevelUpKalineTree : pb::IMessage<LevelUpKalineTree>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<LevelUpKalineTree> _parser = new pb::MessageParser<LevelUpKalineTree>(() => new LevelUpKalineTree());
     private pb::UnknownFieldSet _unknownFields;
@@ -6431,19 +7356,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[23]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpKalineTree() {
+    public LevelUpKalineTree()
+    {
       OnConstruction();
     }
 
@@ -6451,14 +7379,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpKalineTree(LevelUpKalineTree other) : this() {
+    public LevelUpKalineTree(LevelUpKalineTree other) : this()
+    {
       userId_ = other.userId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public LevelUpKalineTree Clone() {
+    public LevelUpKalineTree Clone()
+    {
       return new LevelUpKalineTree(this);
     }
 
@@ -6467,26 +7397,32 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as LevelUpKalineTree);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(LevelUpKalineTree other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(LevelUpKalineTree other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -6495,10 +7431,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -6506,16 +7444,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -6523,31 +7463,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -6555,11 +7501,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(LevelUpKalineTree other) {
-      if (other == null) {
+    public void MergeFrom(LevelUpKalineTree other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -6567,10 +7516,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -6583,35 +7533,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WebSocketResponse : pb::IMessage<WebSocketResponse>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<WebSocketResponse> _parser = new pb::MessageParser<WebSocketResponse>(() => new WebSocketResponse());
     private pb::UnknownFieldSet _unknownFields;
@@ -6621,19 +7575,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[24]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public WebSocketResponse() {
+    public WebSocketResponse()
+    {
       OnConstruction();
     }
 
@@ -6641,8 +7598,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public WebSocketResponse(WebSocketResponse other) : this() {
-      switch (other.ResponseTypeCase) {
+    public WebSocketResponse(WebSocketResponse other) : this()
+    {
+      switch (other.ResponseTypeCase)
+      {
         case ResponseTypeOneofCase.User:
           User = other.User.Clone();
           break;
@@ -6695,7 +7654,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public WebSocketResponse Clone() {
+    public WebSocketResponse Clone()
+    {
       return new WebSocketResponse(this);
     }
 
@@ -6703,9 +7663,11 @@ namespace Protobuf.Messages {
     public const int UserFieldNumber = 1;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.User User {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.User ? (global::Protobuf.Messages.User) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.User User
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.User ? (global::Protobuf.Messages.User)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.User;
       }
@@ -6715,9 +7677,11 @@ namespace Protobuf.Messages {
     public const int UnitFieldNumber = 2;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Unit Unit {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Unit ? (global::Protobuf.Messages.Unit) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Unit Unit
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Unit ? (global::Protobuf.Messages.Unit)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Unit;
       }
@@ -6727,9 +7691,11 @@ namespace Protobuf.Messages {
     public const int UnitsFieldNumber = 3;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Units Units {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Units ? (global::Protobuf.Messages.Units) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Units Units
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Units ? (global::Protobuf.Messages.Units)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Units;
       }
@@ -6739,9 +7705,11 @@ namespace Protobuf.Messages {
     public const int UnitAndCurrenciesFieldNumber = 4;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.UnitAndCurrencies UnitAndCurrencies {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.UnitAndCurrencies ? (global::Protobuf.Messages.UnitAndCurrencies) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.UnitAndCurrencies UnitAndCurrencies
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.UnitAndCurrencies ? (global::Protobuf.Messages.UnitAndCurrencies)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.UnitAndCurrencies;
       }
@@ -6751,9 +7719,11 @@ namespace Protobuf.Messages {
     public const int ItemFieldNumber = 5;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Item Item {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Item ? (global::Protobuf.Messages.Item) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Item Item
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Item ? (global::Protobuf.Messages.Item)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Item;
       }
@@ -6763,9 +7733,11 @@ namespace Protobuf.Messages {
     public const int CampaignsFieldNumber = 6;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Campaigns Campaigns {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Campaigns ? (global::Protobuf.Messages.Campaigns) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Campaigns Campaigns
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Campaigns ? (global::Protobuf.Messages.Campaigns)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Campaigns;
       }
@@ -6775,9 +7747,11 @@ namespace Protobuf.Messages {
     public const int CampaignFieldNumber = 7;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Campaign Campaign {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Campaign ? (global::Protobuf.Messages.Campaign) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Campaign Campaign
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Campaign ? (global::Protobuf.Messages.Campaign)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Campaign;
       }
@@ -6787,9 +7761,11 @@ namespace Protobuf.Messages {
     public const int LevelFieldNumber = 8;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Level Level {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Level ? (global::Protobuf.Messages.Level) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Level Level
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Level ? (global::Protobuf.Messages.Level)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Level;
       }
@@ -6799,9 +7775,11 @@ namespace Protobuf.Messages {
     public const int BattleResultFieldNumber = 9;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.BattleResult BattleResult {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.BattleResult ? (global::Protobuf.Messages.BattleResult) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.BattleResult BattleResult
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.BattleResult ? (global::Protobuf.Messages.BattleResult)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.BattleResult;
       }
@@ -6811,9 +7789,11 @@ namespace Protobuf.Messages {
     public const int ErrorFieldNumber = 10;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Error Error {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Error ? (global::Protobuf.Messages.Error) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Error Error
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Error ? (global::Protobuf.Messages.Error)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Error;
       }
@@ -6823,9 +7803,11 @@ namespace Protobuf.Messages {
     public const int BoxesFieldNumber = 11;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Boxes Boxes {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Boxes ? (global::Protobuf.Messages.Boxes) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Boxes Boxes
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Boxes ? (global::Protobuf.Messages.Boxes)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Boxes;
       }
@@ -6835,9 +7817,11 @@ namespace Protobuf.Messages {
     public const int BoxFieldNumber = 12;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Box Box {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.Box ? (global::Protobuf.Messages.Box) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.Box Box
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.Box ? (global::Protobuf.Messages.Box)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.Box;
       }
@@ -6847,9 +7831,11 @@ namespace Protobuf.Messages {
     public const int UserAndUnitFieldNumber = 13;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.UserAndUnit UserAndUnit {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit ? (global::Protobuf.Messages.UserAndUnit) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.UserAndUnit UserAndUnit
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit ? (global::Protobuf.Messages.UserAndUnit)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.UserAndUnit;
       }
@@ -6859,9 +7845,11 @@ namespace Protobuf.Messages {
     public const int AfkRewardsFieldNumber = 14;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.AfkRewards AfkRewards {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.AfkRewards ? (global::Protobuf.Messages.AfkRewards) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.AfkRewards AfkRewards
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.AfkRewards ? (global::Protobuf.Messages.AfkRewards)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.AfkRewards;
       }
@@ -6871,9 +7859,11 @@ namespace Protobuf.Messages {
     public const int SuperCampaignProgressesFieldNumber = 15;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.SuperCampaignProgresses SuperCampaignProgresses {
-      get { return responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses ? (global::Protobuf.Messages.SuperCampaignProgresses) responseType_ : null; }
-      set {
+    public global::Protobuf.Messages.SuperCampaignProgresses SuperCampaignProgresses
+    {
+      get { return responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses ? (global::Protobuf.Messages.SuperCampaignProgresses)responseType_ : null; }
+      set
+      {
         responseType_ = value;
         responseTypeCase_ = value == null ? ResponseTypeOneofCase.None : ResponseTypeOneofCase.SuperCampaignProgresses;
       }
@@ -6881,7 +7871,8 @@ namespace Protobuf.Messages {
 
     private object responseType_;
     /// <summary>Enum of possible cases for the "response_type" oneof.</summary>
-    public enum ResponseTypeOneofCase {
+    public enum ResponseTypeOneofCase
+    {
       None = 0,
       User = 1,
       Unit = 2,
@@ -6902,30 +7893,36 @@ namespace Protobuf.Messages {
     private ResponseTypeOneofCase responseTypeCase_ = ResponseTypeOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ResponseTypeOneofCase ResponseTypeCase {
+    public ResponseTypeOneofCase ResponseTypeCase
+    {
       get { return responseTypeCase_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void ClearResponseType() {
+    public void ClearResponseType()
+    {
       responseTypeCase_ = ResponseTypeOneofCase.None;
       responseType_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as WebSocketResponse);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(WebSocketResponse other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(WebSocketResponse other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(User, other.User)) return false;
@@ -6949,7 +7946,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (responseTypeCase_ == ResponseTypeOneofCase.User) hash ^= User.GetHashCode();
       if (responseTypeCase_ == ResponseTypeOneofCase.Unit) hash ^= Unit.GetHashCode();
@@ -6966,8 +7964,9 @@ namespace Protobuf.Messages {
       if (responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit) hash ^= UserAndUnit.GetHashCode();
       if (responseTypeCase_ == ResponseTypeOneofCase.AfkRewards) hash ^= AfkRewards.GetHashCode();
       if (responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses) hash ^= SuperCampaignProgresses.GetHashCode();
-      hash ^= (int) responseTypeCase_;
-      if (_unknownFields != null) {
+      hash ^= (int)responseTypeCase_;
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -6975,16 +7974,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (responseTypeCase_ == ResponseTypeOneofCase.User) {
         output.WriteRawTag(10);
         output.WriteMessage(User);
@@ -7048,129 +8049,163 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (responseTypeCase_ == ResponseTypeOneofCase.User) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (responseTypeCase_ == ResponseTypeOneofCase.User)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(User);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Unit) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Unit)
+      {
         output.WriteRawTag(18);
         output.WriteMessage(Unit);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Units) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Units)
+      {
         output.WriteRawTag(26);
         output.WriteMessage(Units);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.UnitAndCurrencies) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.UnitAndCurrencies)
+      {
         output.WriteRawTag(34);
         output.WriteMessage(UnitAndCurrencies);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Item) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Item)
+      {
         output.WriteRawTag(42);
         output.WriteMessage(Item);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Campaigns) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Campaigns)
+      {
         output.WriteRawTag(50);
         output.WriteMessage(Campaigns);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Campaign) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Campaign)
+      {
         output.WriteRawTag(58);
         output.WriteMessage(Campaign);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Level) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Level)
+      {
         output.WriteRawTag(66);
         output.WriteMessage(Level);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.BattleResult) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.BattleResult)
+      {
         output.WriteRawTag(74);
         output.WriteMessage(BattleResult);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Error) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Error)
+      {
         output.WriteRawTag(82);
         output.WriteMessage(Error);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Boxes) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Boxes)
+      {
         output.WriteRawTag(90);
         output.WriteMessage(Boxes);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Box) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Box)
+      {
         output.WriteRawTag(98);
         output.WriteMessage(Box);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit)
+      {
         output.WriteRawTag(106);
         output.WriteMessage(UserAndUnit);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.AfkRewards) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.AfkRewards)
+      {
         output.WriteRawTag(114);
         output.WriteMessage(AfkRewards);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses)
+      {
         output.WriteRawTag(122);
         output.WriteMessage(SuperCampaignProgresses);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (responseTypeCase_ == ResponseTypeOneofCase.User) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.User)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(User);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Unit) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Unit)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Unit);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Units) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Units)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Units);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.UnitAndCurrencies) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.UnitAndCurrencies)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(UnitAndCurrencies);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Item) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Item)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Item);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Campaigns) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Campaigns)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Campaigns);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Campaign) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Campaign)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Campaign);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Level) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Level)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Level);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.BattleResult) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.BattleResult)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(BattleResult);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Error) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Error)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Error);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Boxes) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Boxes)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Boxes);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.Box) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.Box)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Box);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(UserAndUnit);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.AfkRewards) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.AfkRewards)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(AfkRewards);
       }
-      if (responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses) {
+      if (responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(SuperCampaignProgresses);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -7178,97 +8213,115 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(WebSocketResponse other) {
-      if (other == null) {
+    public void MergeFrom(WebSocketResponse other)
+    {
+      if (other == null)
+      {
         return;
       }
-      switch (other.ResponseTypeCase) {
+      switch (other.ResponseTypeCase)
+      {
         case ResponseTypeOneofCase.User:
-          if (User == null) {
+          if (User == null)
+          {
             User = new global::Protobuf.Messages.User();
           }
           User.MergeFrom(other.User);
           break;
         case ResponseTypeOneofCase.Unit:
-          if (Unit == null) {
+          if (Unit == null)
+          {
             Unit = new global::Protobuf.Messages.Unit();
           }
           Unit.MergeFrom(other.Unit);
           break;
         case ResponseTypeOneofCase.Units:
-          if (Units == null) {
+          if (Units == null)
+          {
             Units = new global::Protobuf.Messages.Units();
           }
           Units.MergeFrom(other.Units);
           break;
         case ResponseTypeOneofCase.UnitAndCurrencies:
-          if (UnitAndCurrencies == null) {
+          if (UnitAndCurrencies == null)
+          {
             UnitAndCurrencies = new global::Protobuf.Messages.UnitAndCurrencies();
           }
           UnitAndCurrencies.MergeFrom(other.UnitAndCurrencies);
           break;
         case ResponseTypeOneofCase.Item:
-          if (Item == null) {
+          if (Item == null)
+          {
             Item = new global::Protobuf.Messages.Item();
           }
           Item.MergeFrom(other.Item);
           break;
         case ResponseTypeOneofCase.Campaigns:
-          if (Campaigns == null) {
+          if (Campaigns == null)
+          {
             Campaigns = new global::Protobuf.Messages.Campaigns();
           }
           Campaigns.MergeFrom(other.Campaigns);
           break;
         case ResponseTypeOneofCase.Campaign:
-          if (Campaign == null) {
+          if (Campaign == null)
+          {
             Campaign = new global::Protobuf.Messages.Campaign();
           }
           Campaign.MergeFrom(other.Campaign);
           break;
         case ResponseTypeOneofCase.Level:
-          if (Level == null) {
+          if (Level == null)
+          {
             Level = new global::Protobuf.Messages.Level();
           }
           Level.MergeFrom(other.Level);
           break;
         case ResponseTypeOneofCase.BattleResult:
-          if (BattleResult == null) {
+          if (BattleResult == null)
+          {
             BattleResult = new global::Protobuf.Messages.BattleResult();
           }
           BattleResult.MergeFrom(other.BattleResult);
           break;
         case ResponseTypeOneofCase.Error:
-          if (Error == null) {
+          if (Error == null)
+          {
             Error = new global::Protobuf.Messages.Error();
           }
           Error.MergeFrom(other.Error);
           break;
         case ResponseTypeOneofCase.Boxes:
-          if (Boxes == null) {
+          if (Boxes == null)
+          {
             Boxes = new global::Protobuf.Messages.Boxes();
           }
           Boxes.MergeFrom(other.Boxes);
           break;
         case ResponseTypeOneofCase.Box:
-          if (Box == null) {
+          if (Box == null)
+          {
             Box = new global::Protobuf.Messages.Box();
           }
           Box.MergeFrom(other.Box);
           break;
         case ResponseTypeOneofCase.UserAndUnit:
-          if (UserAndUnit == null) {
+          if (UserAndUnit == null)
+          {
             UserAndUnit = new global::Protobuf.Messages.UserAndUnit();
           }
           UserAndUnit.MergeFrom(other.UserAndUnit);
           break;
         case ResponseTypeOneofCase.AfkRewards:
-          if (AfkRewards == null) {
+          if (AfkRewards == null)
+          {
             AfkRewards = new global::Protobuf.Messages.AfkRewards();
           }
           AfkRewards.MergeFrom(other.AfkRewards);
           break;
         case ResponseTypeOneofCase.SuperCampaignProgresses:
-          if (SuperCampaignProgresses == null) {
+          if (SuperCampaignProgresses == null)
+          {
             SuperCampaignProgresses = new global::Protobuf.Messages.SuperCampaignProgresses();
           }
           SuperCampaignProgresses.MergeFrom(other.SuperCampaignProgresses);
@@ -7280,10 +8333,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -7427,166 +8481,199 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            global::Protobuf.Messages.User subBuilder = new global::Protobuf.Messages.User();
-            if (responseTypeCase_ == ResponseTypeOneofCase.User) {
-              subBuilder.MergeFrom(User);
+          case 10:
+            {
+              global::Protobuf.Messages.User subBuilder = new global::Protobuf.Messages.User();
+              if (responseTypeCase_ == ResponseTypeOneofCase.User)
+              {
+                subBuilder.MergeFrom(User);
+              }
+              input.ReadMessage(subBuilder);
+              User = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            User = subBuilder;
-            break;
-          }
-          case 18: {
-            global::Protobuf.Messages.Unit subBuilder = new global::Protobuf.Messages.Unit();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Unit) {
-              subBuilder.MergeFrom(Unit);
+          case 18:
+            {
+              global::Protobuf.Messages.Unit subBuilder = new global::Protobuf.Messages.Unit();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Unit)
+              {
+                subBuilder.MergeFrom(Unit);
+              }
+              input.ReadMessage(subBuilder);
+              Unit = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Unit = subBuilder;
-            break;
-          }
-          case 26: {
-            global::Protobuf.Messages.Units subBuilder = new global::Protobuf.Messages.Units();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Units) {
-              subBuilder.MergeFrom(Units);
+          case 26:
+            {
+              global::Protobuf.Messages.Units subBuilder = new global::Protobuf.Messages.Units();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Units)
+              {
+                subBuilder.MergeFrom(Units);
+              }
+              input.ReadMessage(subBuilder);
+              Units = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Units = subBuilder;
-            break;
-          }
-          case 34: {
-            global::Protobuf.Messages.UnitAndCurrencies subBuilder = new global::Protobuf.Messages.UnitAndCurrencies();
-            if (responseTypeCase_ == ResponseTypeOneofCase.UnitAndCurrencies) {
-              subBuilder.MergeFrom(UnitAndCurrencies);
+          case 34:
+            {
+              global::Protobuf.Messages.UnitAndCurrencies subBuilder = new global::Protobuf.Messages.UnitAndCurrencies();
+              if (responseTypeCase_ == ResponseTypeOneofCase.UnitAndCurrencies)
+              {
+                subBuilder.MergeFrom(UnitAndCurrencies);
+              }
+              input.ReadMessage(subBuilder);
+              UnitAndCurrencies = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            UnitAndCurrencies = subBuilder;
-            break;
-          }
-          case 42: {
-            global::Protobuf.Messages.Item subBuilder = new global::Protobuf.Messages.Item();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Item) {
-              subBuilder.MergeFrom(Item);
+          case 42:
+            {
+              global::Protobuf.Messages.Item subBuilder = new global::Protobuf.Messages.Item();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Item)
+              {
+                subBuilder.MergeFrom(Item);
+              }
+              input.ReadMessage(subBuilder);
+              Item = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Item = subBuilder;
-            break;
-          }
-          case 50: {
-            global::Protobuf.Messages.Campaigns subBuilder = new global::Protobuf.Messages.Campaigns();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Campaigns) {
-              subBuilder.MergeFrom(Campaigns);
+          case 50:
+            {
+              global::Protobuf.Messages.Campaigns subBuilder = new global::Protobuf.Messages.Campaigns();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Campaigns)
+              {
+                subBuilder.MergeFrom(Campaigns);
+              }
+              input.ReadMessage(subBuilder);
+              Campaigns = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Campaigns = subBuilder;
-            break;
-          }
-          case 58: {
-            global::Protobuf.Messages.Campaign subBuilder = new global::Protobuf.Messages.Campaign();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Campaign) {
-              subBuilder.MergeFrom(Campaign);
+          case 58:
+            {
+              global::Protobuf.Messages.Campaign subBuilder = new global::Protobuf.Messages.Campaign();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Campaign)
+              {
+                subBuilder.MergeFrom(Campaign);
+              }
+              input.ReadMessage(subBuilder);
+              Campaign = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Campaign = subBuilder;
-            break;
-          }
-          case 66: {
-            global::Protobuf.Messages.Level subBuilder = new global::Protobuf.Messages.Level();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Level) {
-              subBuilder.MergeFrom(Level);
+          case 66:
+            {
+              global::Protobuf.Messages.Level subBuilder = new global::Protobuf.Messages.Level();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Level)
+              {
+                subBuilder.MergeFrom(Level);
+              }
+              input.ReadMessage(subBuilder);
+              Level = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Level = subBuilder;
-            break;
-          }
-          case 74: {
-            global::Protobuf.Messages.BattleResult subBuilder = new global::Protobuf.Messages.BattleResult();
-            if (responseTypeCase_ == ResponseTypeOneofCase.BattleResult) {
-              subBuilder.MergeFrom(BattleResult);
+          case 74:
+            {
+              global::Protobuf.Messages.BattleResult subBuilder = new global::Protobuf.Messages.BattleResult();
+              if (responseTypeCase_ == ResponseTypeOneofCase.BattleResult)
+              {
+                subBuilder.MergeFrom(BattleResult);
+              }
+              input.ReadMessage(subBuilder);
+              BattleResult = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            BattleResult = subBuilder;
-            break;
-          }
-          case 82: {
-            global::Protobuf.Messages.Error subBuilder = new global::Protobuf.Messages.Error();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Error) {
-              subBuilder.MergeFrom(Error);
+          case 82:
+            {
+              global::Protobuf.Messages.Error subBuilder = new global::Protobuf.Messages.Error();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Error)
+              {
+                subBuilder.MergeFrom(Error);
+              }
+              input.ReadMessage(subBuilder);
+              Error = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Error = subBuilder;
-            break;
-          }
-          case 90: {
-            global::Protobuf.Messages.Boxes subBuilder = new global::Protobuf.Messages.Boxes();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Boxes) {
-              subBuilder.MergeFrom(Boxes);
+          case 90:
+            {
+              global::Protobuf.Messages.Boxes subBuilder = new global::Protobuf.Messages.Boxes();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Boxes)
+              {
+                subBuilder.MergeFrom(Boxes);
+              }
+              input.ReadMessage(subBuilder);
+              Boxes = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Boxes = subBuilder;
-            break;
-          }
-          case 98: {
-            global::Protobuf.Messages.Box subBuilder = new global::Protobuf.Messages.Box();
-            if (responseTypeCase_ == ResponseTypeOneofCase.Box) {
-              subBuilder.MergeFrom(Box);
+          case 98:
+            {
+              global::Protobuf.Messages.Box subBuilder = new global::Protobuf.Messages.Box();
+              if (responseTypeCase_ == ResponseTypeOneofCase.Box)
+              {
+                subBuilder.MergeFrom(Box);
+              }
+              input.ReadMessage(subBuilder);
+              Box = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Box = subBuilder;
-            break;
-          }
-          case 106: {
-            global::Protobuf.Messages.UserAndUnit subBuilder = new global::Protobuf.Messages.UserAndUnit();
-            if (responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit) {
-              subBuilder.MergeFrom(UserAndUnit);
+          case 106:
+            {
+              global::Protobuf.Messages.UserAndUnit subBuilder = new global::Protobuf.Messages.UserAndUnit();
+              if (responseTypeCase_ == ResponseTypeOneofCase.UserAndUnit)
+              {
+                subBuilder.MergeFrom(UserAndUnit);
+              }
+              input.ReadMessage(subBuilder);
+              UserAndUnit = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            UserAndUnit = subBuilder;
-            break;
-          }
-          case 114: {
-            global::Protobuf.Messages.AfkRewards subBuilder = new global::Protobuf.Messages.AfkRewards();
-            if (responseTypeCase_ == ResponseTypeOneofCase.AfkRewards) {
-              subBuilder.MergeFrom(AfkRewards);
+          case 114:
+            {
+              global::Protobuf.Messages.AfkRewards subBuilder = new global::Protobuf.Messages.AfkRewards();
+              if (responseTypeCase_ == ResponseTypeOneofCase.AfkRewards)
+              {
+                subBuilder.MergeFrom(AfkRewards);
+              }
+              input.ReadMessage(subBuilder);
+              AfkRewards = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            AfkRewards = subBuilder;
-            break;
-          }
-          case 122: {
-            global::Protobuf.Messages.SuperCampaignProgresses subBuilder = new global::Protobuf.Messages.SuperCampaignProgresses();
-            if (responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses) {
-              subBuilder.MergeFrom(SuperCampaignProgresses);
+          case 122:
+            {
+              global::Protobuf.Messages.SuperCampaignProgresses subBuilder = new global::Protobuf.Messages.SuperCampaignProgresses();
+              if (responseTypeCase_ == ResponseTypeOneofCase.SuperCampaignProgresses)
+              {
+                subBuilder.MergeFrom(SuperCampaignProgresses);
+              }
+              input.ReadMessage(subBuilder);
+              SuperCampaignProgresses = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            SuperCampaignProgresses = subBuilder;
-            break;
-          }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class User : pb::IMessage<User>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<User> _parser = new pb::MessageParser<User>(() => new User());
     private pb::UnknownFieldSet _unknownFields;
@@ -7596,19 +8683,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[25]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public User() {
+    public User()
+    {
       OnConstruction();
     }
 
@@ -7616,7 +8706,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public User(User other) : this() {
+    public User(User other) : this()
+    {
       id_ = other.id_;
       username_ = other.username_;
       level_ = other.level_;
@@ -7630,7 +8721,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public User Clone() {
+    public User Clone()
+    {
       return new User(this);
     }
 
@@ -7639,9 +8731,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -7651,9 +8745,11 @@ namespace Protobuf.Messages {
     private string username_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Username {
+    public string Username
+    {
       get { return username_; }
-      set {
+      set
+      {
         username_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -7663,9 +8759,11 @@ namespace Protobuf.Messages {
     private ulong level_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ulong Level {
+    public ulong Level
+    {
       get { return level_; }
-      set {
+      set
+      {
         level_ = value;
       }
     }
@@ -7675,9 +8773,11 @@ namespace Protobuf.Messages {
     private ulong experience_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ulong Experience {
+    public ulong Experience
+    {
       get { return experience_; }
-      set {
+      set
+      {
         experience_ = value;
       }
     }
@@ -7689,7 +8789,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.UserCurrency> currencies_ = new pbc::RepeatedField<global::Protobuf.Messages.UserCurrency>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.UserCurrency> Currencies {
+    public pbc::RepeatedField<global::Protobuf.Messages.UserCurrency> Currencies
+    {
       get { return currencies_; }
     }
 
@@ -7700,7 +8801,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Unit> units_ = new pbc::RepeatedField<global::Protobuf.Messages.Unit>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Unit> Units {
+    public pbc::RepeatedField<global::Protobuf.Messages.Unit> Units
+    {
       get { return units_; }
     }
 
@@ -7711,7 +8813,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Item> items_ = new pbc::RepeatedField<global::Protobuf.Messages.Item>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Item> Items {
+    public pbc::RepeatedField<global::Protobuf.Messages.Item> Items
+    {
       get { return items_; }
     }
 
@@ -7720,42 +8823,49 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.KalineTreeLevel kalineTreeLevel_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.KalineTreeLevel KalineTreeLevel {
+    public global::Protobuf.Messages.KalineTreeLevel KalineTreeLevel
+    {
       get { return kalineTreeLevel_; }
-      set {
+      set
+      {
         kalineTreeLevel_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as User);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(User other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(User other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
       if (Username != other.Username) return false;
       if (Level != other.Level) return false;
       if (Experience != other.Experience) return false;
-      if(!currencies_.Equals(other.currencies_)) return false;
-      if(!units_.Equals(other.units_)) return false;
-      if(!items_.Equals(other.items_)) return false;
+      if (!currencies_.Equals(other.currencies_)) return false;
+      if (!units_.Equals(other.units_)) return false;
+      if (!items_.Equals(other.items_)) return false;
       if (!object.Equals(KalineTreeLevel, other.KalineTreeLevel)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (Username.Length != 0) hash ^= Username.GetHashCode();
@@ -7765,7 +8875,8 @@ namespace Protobuf.Messages {
       hash ^= units_.GetHashCode();
       hash ^= items_.GetHashCode();
       if (kalineTreeLevel_ != null) hash ^= KalineTreeLevel.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -7773,16 +8884,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -7809,65 +8922,79 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (Username.Length != 0) {
+      if (Username.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(Username);
       }
-      if (Level != 0UL) {
+      if (Level != 0UL)
+      {
         output.WriteRawTag(24);
         output.WriteUInt64(Level);
       }
-      if (Experience != 0UL) {
+      if (Experience != 0UL)
+      {
         output.WriteRawTag(32);
         output.WriteUInt64(Experience);
       }
       currencies_.WriteTo(ref output, _repeated_currencies_codec);
       units_.WriteTo(ref output, _repeated_units_codec);
       items_.WriteTo(ref output, _repeated_items_codec);
-      if (kalineTreeLevel_ != null) {
+      if (kalineTreeLevel_ != null)
+      {
         output.WriteRawTag(82);
         output.WriteMessage(KalineTreeLevel);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (Username.Length != 0) {
+      if (Username.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Username);
       }
-      if (Level != 0UL) {
+      if (Level != 0UL)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt64Size(Level);
       }
-      if (Experience != 0UL) {
+      if (Experience != 0UL)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt64Size(Experience);
       }
       size += currencies_.CalculateSize(_repeated_currencies_codec);
       size += units_.CalculateSize(_repeated_units_codec);
       size += items_.CalculateSize(_repeated_items_codec);
-      if (kalineTreeLevel_ != null) {
+      if (kalineTreeLevel_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(KalineTreeLevel);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -7875,27 +9002,35 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(User other) {
-      if (other == null) {
+    public void MergeFrom(User other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.Username.Length != 0) {
+      if (other.Username.Length != 0)
+      {
         Username = other.Username;
       }
-      if (other.Level != 0UL) {
+      if (other.Level != 0UL)
+      {
         Level = other.Level;
       }
-      if (other.Experience != 0UL) {
+      if (other.Experience != 0UL)
+      {
         Experience = other.Experience;
       }
       currencies_.Add(other.currencies_);
       units_.Add(other.units_);
       items_.Add(other.items_);
-      if (other.kalineTreeLevel_ != null) {
-        if (kalineTreeLevel_ == null) {
+      if (other.kalineTreeLevel_ != null)
+      {
+        if (kalineTreeLevel_ == null)
+        {
           KalineTreeLevel = new global::Protobuf.Messages.KalineTreeLevel();
         }
         KalineTreeLevel.MergeFrom(other.KalineTreeLevel);
@@ -7905,10 +9040,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -7952,66 +9088,78 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 18: {
-            Username = input.ReadString();
-            break;
-          }
-          case 24: {
-            Level = input.ReadUInt64();
-            break;
-          }
-          case 32: {
-            Experience = input.ReadUInt64();
-            break;
-          }
-          case 58: {
-            currencies_.AddEntriesFrom(ref input, _repeated_currencies_codec);
-            break;
-          }
-          case 66: {
-            units_.AddEntriesFrom(ref input, _repeated_units_codec);
-            break;
-          }
-          case 74: {
-            items_.AddEntriesFrom(ref input, _repeated_items_codec);
-            break;
-          }
-          case 82: {
-            if (kalineTreeLevel_ == null) {
-              KalineTreeLevel = new global::Protobuf.Messages.KalineTreeLevel();
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
             }
-            input.ReadMessage(KalineTreeLevel);
-            break;
-          }
+          case 18:
+            {
+              Username = input.ReadString();
+              break;
+            }
+          case 24:
+            {
+              Level = input.ReadUInt64();
+              break;
+            }
+          case 32:
+            {
+              Experience = input.ReadUInt64();
+              break;
+            }
+          case 58:
+            {
+              currencies_.AddEntriesFrom(ref input, _repeated_currencies_codec);
+              break;
+            }
+          case 66:
+            {
+              units_.AddEntriesFrom(ref input, _repeated_units_codec);
+              break;
+            }
+          case 74:
+            {
+              items_.AddEntriesFrom(ref input, _repeated_items_codec);
+              break;
+            }
+          case 82:
+            {
+              if (kalineTreeLevel_ == null)
+              {
+                KalineTreeLevel = new global::Protobuf.Messages.KalineTreeLevel();
+              }
+              input.ReadMessage(KalineTreeLevel);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class KalineTreeLevel : pb::IMessage<KalineTreeLevel>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<KalineTreeLevel> _parser = new pb::MessageParser<KalineTreeLevel>(() => new KalineTreeLevel());
     private pb::UnknownFieldSet _unknownFields;
@@ -8021,19 +9169,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[26]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public KalineTreeLevel() {
+    public KalineTreeLevel()
+    {
       OnConstruction();
     }
 
@@ -8041,7 +9192,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public KalineTreeLevel(KalineTreeLevel other) : this() {
+    public KalineTreeLevel(KalineTreeLevel other) : this()
+    {
       id_ = other.id_;
       level_ = other.level_;
       fertilizerLevelUpCost_ = other.fertilizerLevelUpCost_;
@@ -8053,7 +9205,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public KalineTreeLevel Clone() {
+    public KalineTreeLevel Clone()
+    {
       return new KalineTreeLevel(this);
     }
 
@@ -8062,9 +9215,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -8074,9 +9229,11 @@ namespace Protobuf.Messages {
     private ulong level_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ulong Level {
+    public ulong Level
+    {
       get { return level_; }
-      set {
+      set
+      {
         level_ = value;
       }
     }
@@ -8086,9 +9243,11 @@ namespace Protobuf.Messages {
     private ulong fertilizerLevelUpCost_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ulong FertilizerLevelUpCost {
+    public ulong FertilizerLevelUpCost
+    {
       get { return fertilizerLevelUpCost_; }
-      set {
+      set
+      {
         fertilizerLevelUpCost_ = value;
       }
     }
@@ -8098,9 +9257,11 @@ namespace Protobuf.Messages {
     private ulong goldLevelUpCost_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ulong GoldLevelUpCost {
+    public ulong GoldLevelUpCost
+    {
       get { return goldLevelUpCost_; }
-      set {
+      set
+      {
         goldLevelUpCost_ = value;
       }
     }
@@ -8112,7 +9273,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<string> unlockFeatures_ = new pbc::RepeatedField<string>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<string> UnlockFeatures {
+    public pbc::RepeatedField<string> UnlockFeatures
+    {
       get { return unlockFeatures_; }
     }
 
@@ -8123,37 +9285,43 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.AfkRewardRate> afkRewardRates_ = new pbc::RepeatedField<global::Protobuf.Messages.AfkRewardRate>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.AfkRewardRate> AfkRewardRates {
+    public pbc::RepeatedField<global::Protobuf.Messages.AfkRewardRate> AfkRewardRates
+    {
       get { return afkRewardRates_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as KalineTreeLevel);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(KalineTreeLevel other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(KalineTreeLevel other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
       if (Level != other.Level) return false;
       if (FertilizerLevelUpCost != other.FertilizerLevelUpCost) return false;
       if (GoldLevelUpCost != other.GoldLevelUpCost) return false;
-      if(!unlockFeatures_.Equals(other.unlockFeatures_)) return false;
-      if(!afkRewardRates_.Equals(other.afkRewardRates_)) return false;
+      if (!unlockFeatures_.Equals(other.unlockFeatures_)) return false;
+      if (!afkRewardRates_.Equals(other.afkRewardRates_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (Level != 0UL) hash ^= Level.GetHashCode();
@@ -8161,7 +9329,8 @@ namespace Protobuf.Messages {
       if (GoldLevelUpCost != 0UL) hash ^= GoldLevelUpCost.GetHashCode();
       hash ^= unlockFeatures_.GetHashCode();
       hash ^= afkRewardRates_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -8169,16 +9338,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -8200,56 +9371,68 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (Level != 0UL) {
+      if (Level != 0UL)
+      {
         output.WriteRawTag(16);
         output.WriteUInt64(Level);
       }
-      if (FertilizerLevelUpCost != 0UL) {
+      if (FertilizerLevelUpCost != 0UL)
+      {
         output.WriteRawTag(24);
         output.WriteUInt64(FertilizerLevelUpCost);
       }
-      if (GoldLevelUpCost != 0UL) {
+      if (GoldLevelUpCost != 0UL)
+      {
         output.WriteRawTag(32);
         output.WriteUInt64(GoldLevelUpCost);
       }
       unlockFeatures_.WriteTo(ref output, _repeated_unlockFeatures_codec);
       afkRewardRates_.WriteTo(ref output, _repeated_afkRewardRates_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (Level != 0UL) {
+      if (Level != 0UL)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt64Size(Level);
       }
-      if (FertilizerLevelUpCost != 0UL) {
+      if (FertilizerLevelUpCost != 0UL)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt64Size(FertilizerLevelUpCost);
       }
-      if (GoldLevelUpCost != 0UL) {
+      if (GoldLevelUpCost != 0UL)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt64Size(GoldLevelUpCost);
       }
       size += unlockFeatures_.CalculateSize(_repeated_unlockFeatures_codec);
       size += afkRewardRates_.CalculateSize(_repeated_afkRewardRates_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -8257,20 +9440,26 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(KalineTreeLevel other) {
-      if (other == null) {
+    public void MergeFrom(KalineTreeLevel other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.Level != 0UL) {
+      if (other.Level != 0UL)
+      {
         Level = other.Level;
       }
-      if (other.FertilizerLevelUpCost != 0UL) {
+      if (other.FertilizerLevelUpCost != 0UL)
+      {
         FertilizerLevelUpCost = other.FertilizerLevelUpCost;
       }
-      if (other.GoldLevelUpCost != 0UL) {
+      if (other.GoldLevelUpCost != 0UL)
+      {
         GoldLevelUpCost = other.GoldLevelUpCost;
       }
       unlockFeatures_.Add(other.unlockFeatures_);
@@ -8280,10 +9469,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -8316,55 +9506,64 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 16: {
-            Level = input.ReadUInt64();
-            break;
-          }
-          case 24: {
-            FertilizerLevelUpCost = input.ReadUInt64();
-            break;
-          }
-          case 32: {
-            GoldLevelUpCost = input.ReadUInt64();
-            break;
-          }
-          case 42: {
-            unlockFeatures_.AddEntriesFrom(ref input, _repeated_unlockFeatures_codec);
-            break;
-          }
-          case 50: {
-            afkRewardRates_.AddEntriesFrom(ref input, _repeated_afkRewardRates_codec);
-            break;
-          }
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
+            }
+          case 16:
+            {
+              Level = input.ReadUInt64();
+              break;
+            }
+          case 24:
+            {
+              FertilizerLevelUpCost = input.ReadUInt64();
+              break;
+            }
+          case 32:
+            {
+              GoldLevelUpCost = input.ReadUInt64();
+              break;
+            }
+          case 42:
+            {
+              unlockFeatures_.AddEntriesFrom(ref input, _repeated_unlockFeatures_codec);
+              break;
+            }
+          case 50:
+            {
+              afkRewardRates_.AddEntriesFrom(ref input, _repeated_afkRewardRates_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SuperCampaignProgresses : pb::IMessage<SuperCampaignProgresses>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<SuperCampaignProgresses> _parser = new pb::MessageParser<SuperCampaignProgresses>(() => new SuperCampaignProgresses());
     private pb::UnknownFieldSet _unknownFields;
@@ -8374,19 +9573,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[27]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SuperCampaignProgresses() {
+    public SuperCampaignProgresses()
+    {
       OnConstruction();
     }
 
@@ -8394,14 +9596,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SuperCampaignProgresses(SuperCampaignProgresses other) : this() {
+    public SuperCampaignProgresses(SuperCampaignProgresses other) : this()
+    {
       superCampaignProgresses_ = other.superCampaignProgresses_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SuperCampaignProgresses Clone() {
+    public SuperCampaignProgresses Clone()
+    {
       return new SuperCampaignProgresses(this);
     }
 
@@ -8412,35 +9616,42 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.SuperCampaignProgress> superCampaignProgresses_ = new pbc::RepeatedField<global::Protobuf.Messages.SuperCampaignProgress>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.SuperCampaignProgress> SuperCampaignProgresses_ {
+    public pbc::RepeatedField<global::Protobuf.Messages.SuperCampaignProgress> SuperCampaignProgresses_
+    {
       get { return superCampaignProgresses_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as SuperCampaignProgresses);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(SuperCampaignProgresses other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(SuperCampaignProgresses other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
-      if(!superCampaignProgresses_.Equals(other.superCampaignProgresses_)) return false;
+      if (!superCampaignProgresses_.Equals(other.superCampaignProgresses_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       hash ^= superCampaignProgresses_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -8448,40 +9659,46 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       superCampaignProgresses_.WriteTo(output, _repeated_superCampaignProgresses_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
       superCampaignProgresses_.WriteTo(ref output, _repeated_superCampaignProgresses_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
       size += superCampaignProgresses_.CalculateSize(_repeated_superCampaignProgresses_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -8489,8 +9706,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(SuperCampaignProgresses other) {
-      if (other == null) {
+    public void MergeFrom(SuperCampaignProgresses other)
+    {
+      if (other == null)
+      {
         return;
       }
       superCampaignProgresses_.Add(other.superCampaignProgresses_);
@@ -8499,10 +9718,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -8515,35 +9735,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            superCampaignProgresses_.AddEntriesFrom(ref input, _repeated_superCampaignProgresses_codec);
-            break;
-          }
+          case 10:
+            {
+              superCampaignProgresses_.AddEntriesFrom(ref input, _repeated_superCampaignProgresses_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SuperCampaignProgress : pb::IMessage<SuperCampaignProgress>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<SuperCampaignProgress> _parser = new pb::MessageParser<SuperCampaignProgress>(() => new SuperCampaignProgress());
     private pb::UnknownFieldSet _unknownFields;
@@ -8553,19 +9777,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[28]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SuperCampaignProgress() {
+    public SuperCampaignProgress()
+    {
       OnConstruction();
     }
 
@@ -8573,7 +9800,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SuperCampaignProgress(SuperCampaignProgress other) : this() {
+    public SuperCampaignProgress(SuperCampaignProgress other) : this()
+    {
       userId_ = other.userId_;
       campaignId_ = other.campaignId_;
       levelId_ = other.levelId_;
@@ -8583,7 +9811,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SuperCampaignProgress Clone() {
+    public SuperCampaignProgress Clone()
+    {
       return new SuperCampaignProgress(this);
     }
 
@@ -8592,9 +9821,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -8604,9 +9835,11 @@ namespace Protobuf.Messages {
     private string campaignId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string CampaignId {
+    public string CampaignId
+    {
       get { return campaignId_; }
-      set {
+      set
+      {
         campaignId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -8616,9 +9849,11 @@ namespace Protobuf.Messages {
     private string levelId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string LevelId {
+    public string LevelId
+    {
       get { return levelId_; }
-      set {
+      set
+      {
         levelId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -8628,26 +9863,32 @@ namespace Protobuf.Messages {
     private string superCampaignName_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SuperCampaignName {
+    public string SuperCampaignName
+    {
       get { return superCampaignName_; }
-      set {
+      set
+      {
         superCampaignName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as SuperCampaignProgress);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(SuperCampaignProgress other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(SuperCampaignProgress other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UserId != other.UserId) return false;
@@ -8659,13 +9900,15 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (CampaignId.Length != 0) hash ^= CampaignId.GetHashCode();
       if (LevelId.Length != 0) hash ^= LevelId.GetHashCode();
       if (SuperCampaignName.Length != 0) hash ^= SuperCampaignName.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -8673,16 +9916,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UserId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UserId);
@@ -8702,52 +9947,64 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UserId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UserId);
       }
-      if (CampaignId.Length != 0) {
+      if (CampaignId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(CampaignId);
       }
-      if (LevelId.Length != 0) {
+      if (LevelId.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(LevelId);
       }
-      if (SuperCampaignName.Length != 0) {
+      if (SuperCampaignName.Length != 0)
+      {
         output.WriteRawTag(34);
         output.WriteString(SuperCampaignName);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (CampaignId.Length != 0) {
+      if (CampaignId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(CampaignId);
       }
-      if (LevelId.Length != 0) {
+      if (LevelId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(LevelId);
       }
-      if (SuperCampaignName.Length != 0) {
+      if (SuperCampaignName.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignName);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -8755,20 +10012,26 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(SuperCampaignProgress other) {
-      if (other == null) {
+    public void MergeFrom(SuperCampaignProgress other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.CampaignId.Length != 0) {
+      if (other.CampaignId.Length != 0)
+      {
         CampaignId = other.CampaignId;
       }
-      if (other.LevelId.Length != 0) {
+      if (other.LevelId.Length != 0)
+      {
         LevelId = other.LevelId;
       }
-      if (other.SuperCampaignName.Length != 0) {
+      if (other.SuperCampaignName.Length != 0)
+      {
         SuperCampaignName = other.SuperCampaignName;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -8776,10 +10039,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -8804,47 +10068,54 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 18: {
-            CampaignId = input.ReadString();
-            break;
-          }
-          case 26: {
-            LevelId = input.ReadString();
-            break;
-          }
-          case 34: {
-            SuperCampaignName = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              CampaignId = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              LevelId = input.ReadString();
+              break;
+            }
+          case 34:
+            {
+              SuperCampaignName = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class AfkRewardRate : pb::IMessage<AfkRewardRate>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<AfkRewardRate> _parser = new pb::MessageParser<AfkRewardRate>(() => new AfkRewardRate());
     private pb::UnknownFieldSet _unknownFields;
@@ -8854,19 +10125,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[29]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkRewardRate() {
+    public AfkRewardRate()
+    {
       OnConstruction();
     }
 
@@ -8874,7 +10148,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkRewardRate(AfkRewardRate other) : this() {
+    public AfkRewardRate(AfkRewardRate other) : this()
+    {
       kalineTreeLevelId_ = other.kalineTreeLevelId_;
       currency_ = other.currency_ != null ? other.currency_.Clone() : null;
       rate_ = other.rate_;
@@ -8883,7 +10158,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkRewardRate Clone() {
+    public AfkRewardRate Clone()
+    {
       return new AfkRewardRate(this);
     }
 
@@ -8892,9 +10168,11 @@ namespace Protobuf.Messages {
     private string kalineTreeLevelId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string KalineTreeLevelId {
+    public string KalineTreeLevelId
+    {
       get { return kalineTreeLevelId_; }
-      set {
+      set
+      {
         kalineTreeLevelId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -8904,54 +10182,64 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Currency currency_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Currency Currency {
+    public global::Protobuf.Messages.Currency Currency
+    {
       get { return currency_; }
-      set {
+      set
+      {
         currency_ = value;
       }
     }
 
-    /// <summary>Field number for the "rate" field.</summary>
+    /// <summary>Field number for the "daily_rate" field.</summary>
     public const int RateFieldNumber = 3;
     private float rate_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public float Rate {
+    public float daily_rate
+    {
       get { return rate_; }
-      set {
+      set
+      {
         rate_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as AfkRewardRate);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(AfkRewardRate other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(AfkRewardRate other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (KalineTreeLevelId != other.KalineTreeLevelId) return false;
       if (!object.Equals(Currency, other.Currency)) return false;
-      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(Rate, other.Rate)) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(daily_rate, other.daily_rate)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (KalineTreeLevelId.Length != 0) hash ^= KalineTreeLevelId.GetHashCode();
       if (currency_ != null) hash ^= Currency.GetHashCode();
-      if (Rate != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(Rate);
-      if (_unknownFields != null) {
+      if (daily_rate != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(daily_rate);
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -8959,16 +10247,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (KalineTreeLevelId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(KalineTreeLevelId);
@@ -8977,52 +10267,62 @@ namespace Protobuf.Messages {
         output.WriteRawTag(18);
         output.WriteMessage(Currency);
       }
-      if (Rate != 0F) {
+      if (daily_rate != 0F) {
         output.WriteRawTag(29);
-        output.WriteFloat(Rate);
+        output.WriteFloat(daily_rate);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (KalineTreeLevelId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (KalineTreeLevelId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(KalineTreeLevelId);
       }
-      if (currency_ != null) {
+      if (currency_ != null)
+      {
         output.WriteRawTag(18);
         output.WriteMessage(Currency);
       }
-      if (Rate != 0F) {
+      if (daily_rate != 0F)
+      {
         output.WriteRawTag(29);
-        output.WriteFloat(Rate);
+        output.WriteFloat(daily_rate);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (KalineTreeLevelId.Length != 0) {
+      if (KalineTreeLevelId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(KalineTreeLevelId);
       }
-      if (currency_ != null) {
+      if (currency_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Currency);
       }
-      if (Rate != 0F) {
+      if (daily_rate != 0F)
+      {
         size += 1 + 4;
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -9030,31 +10330,38 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(AfkRewardRate other) {
-      if (other == null) {
+    public void MergeFrom(AfkRewardRate other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.KalineTreeLevelId.Length != 0) {
+      if (other.KalineTreeLevelId.Length != 0)
+      {
         KalineTreeLevelId = other.KalineTreeLevelId;
       }
-      if (other.currency_ != null) {
-        if (currency_ == null) {
+      if (other.currency_ != null)
+      {
+        if (currency_ == null)
+        {
           Currency = new global::Protobuf.Messages.Currency();
         }
         Currency.MergeFrom(other.Currency);
       }
-      if (other.Rate != 0F) {
-        Rate = other.Rate;
+      if (other.daily_rate != 0F)
+      {
+        daily_rate = other.daily_rate;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -9073,51 +10380,58 @@ namespace Protobuf.Messages {
             break;
           }
           case 29: {
-            Rate = input.ReadFloat();
+            daily_rate = input.ReadFloat();
             break;
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            KalineTreeLevelId = input.ReadString();
-            break;
-          }
-          case 18: {
-            if (currency_ == null) {
-              Currency = new global::Protobuf.Messages.Currency();
+          case 10:
+            {
+              KalineTreeLevelId = input.ReadString();
+              break;
             }
-            input.ReadMessage(Currency);
-            break;
-          }
-          case 29: {
-            Rate = input.ReadFloat();
-            break;
-          }
+          case 18:
+            {
+              if (currency_ == null)
+              {
+                Currency = new global::Protobuf.Messages.Currency();
+              }
+              input.ReadMessage(Currency);
+              break;
+            }
+          case 29:
+            {
+              daily_rate = input.ReadFloat();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UserCurrency : pb::IMessage<UserCurrency>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<UserCurrency> _parser = new pb::MessageParser<UserCurrency>(() => new UserCurrency());
     private pb::UnknownFieldSet _unknownFields;
@@ -9127,19 +10441,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[30]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UserCurrency() {
+    public UserCurrency()
+    {
       OnConstruction();
     }
 
@@ -9147,7 +10464,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UserCurrency(UserCurrency other) : this() {
+    public UserCurrency(UserCurrency other) : this()
+    {
       currency_ = other.currency_ != null ? other.currency_.Clone() : null;
       amount_ = other.amount_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -9155,7 +10473,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UserCurrency Clone() {
+    public UserCurrency Clone()
+    {
       return new UserCurrency(this);
     }
 
@@ -9164,9 +10483,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Currency currency_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Currency Currency {
+    public global::Protobuf.Messages.Currency Currency
+    {
       get { return currency_; }
-      set {
+      set
+      {
         currency_ = value;
       }
     }
@@ -9176,26 +10497,32 @@ namespace Protobuf.Messages {
     private uint amount_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint Amount {
+    public uint Amount
+    {
       get { return amount_; }
-      set {
+      set
+      {
         amount_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as UserCurrency);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(UserCurrency other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(UserCurrency other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(Currency, other.Currency)) return false;
@@ -9205,11 +10532,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (currency_ != null) hash ^= Currency.GetHashCode();
       if (Amount != 0) hash ^= Amount.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -9217,16 +10546,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (currency_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Currency);
@@ -9238,38 +10569,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (currency_ != null) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (currency_ != null)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(Currency);
       }
-      if (Amount != 0) {
+      if (Amount != 0)
+      {
         output.WriteRawTag(16);
         output.WriteUInt32(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (currency_ != null) {
+      if (currency_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Currency);
       }
-      if (Amount != 0) {
+      if (Amount != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -9277,17 +10616,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(UserCurrency other) {
-      if (other == null) {
+    public void MergeFrom(UserCurrency other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.currency_ != null) {
-        if (currency_ == null) {
+      if (other.currency_ != null)
+      {
+        if (currency_ == null)
+        {
           Currency = new global::Protobuf.Messages.Currency();
         }
         Currency.MergeFrom(other.Currency);
       }
-      if (other.Amount != 0) {
+      if (other.Amount != 0)
+      {
         Amount = other.Amount;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -9295,10 +10639,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -9318,42 +10663,48 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            if (currency_ == null) {
-              Currency = new global::Protobuf.Messages.Currency();
+          case 10:
+            {
+              if (currency_ == null)
+              {
+                Currency = new global::Protobuf.Messages.Currency();
+              }
+              input.ReadMessage(Currency);
+              break;
             }
-            input.ReadMessage(Currency);
-            break;
-          }
-          case 16: {
-            Amount = input.ReadUInt32();
-            break;
-          }
+          case 16:
+            {
+              Amount = input.ReadUInt32();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Currency : pb::IMessage<Currency>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Currency> _parser = new pb::MessageParser<Currency>(() => new Currency());
     private pb::UnknownFieldSet _unknownFields;
@@ -9363,19 +10714,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[31]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Currency() {
+    public Currency()
+    {
       OnConstruction();
     }
 
@@ -9383,14 +10737,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Currency(Currency other) : this() {
+    public Currency(Currency other) : this()
+    {
       name_ = other.name_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Currency Clone() {
+    public Currency Clone()
+    {
       return new Currency(this);
     }
 
@@ -9399,26 +10755,32 @@ namespace Protobuf.Messages {
     private string name_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Name {
+    public string Name
+    {
       get { return name_; }
-      set {
+      set
+      {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Currency);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Currency other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Currency other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Name != other.Name) return false;
@@ -9427,10 +10789,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Name.Length != 0) hash ^= Name.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -9438,16 +10802,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -9455,31 +10821,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Name.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Name.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Name);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Name.Length != 0) {
+      if (Name.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -9487,11 +10859,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Currency other) {
-      if (other == null) {
+    public void MergeFrom(Currency other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Name.Length != 0) {
+      if (other.Name.Length != 0)
+      {
         Name = other.Name;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -9499,10 +10874,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -9515,35 +10891,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Name = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              Name = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Unit : pb::IMessage<Unit>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Unit> _parser = new pb::MessageParser<Unit>(() => new Unit());
     private pb::UnknownFieldSet _unknownFields;
@@ -9553,19 +10933,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[32]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Unit() {
+    public Unit()
+    {
       OnConstruction();
     }
 
@@ -9573,7 +10956,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Unit(Unit other) : this() {
+    public Unit(Unit other) : this()
+    {
       id_ = other.id_;
       level_ = other.level_;
       tier_ = other.tier_;
@@ -9589,7 +10973,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Unit Clone() {
+    public Unit Clone()
+    {
       return new Unit(this);
     }
 
@@ -9598,9 +10983,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -9610,9 +10997,11 @@ namespace Protobuf.Messages {
     private uint level_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint Level {
+    public uint Level
+    {
       get { return level_; }
-      set {
+      set
+      {
         level_ = value;
       }
     }
@@ -9622,9 +11011,11 @@ namespace Protobuf.Messages {
     private uint tier_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint Tier {
+    public uint Tier
+    {
       get { return tier_; }
-      set {
+      set
+      {
         tier_ = value;
       }
     }
@@ -9634,9 +11025,11 @@ namespace Protobuf.Messages {
     private uint rank_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint Rank {
+    public uint Rank
+    {
       get { return rank_; }
-      set {
+      set
+      {
         rank_ = value;
       }
     }
@@ -9646,9 +11039,11 @@ namespace Protobuf.Messages {
     private bool selected_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Selected {
+    public bool Selected
+    {
       get { return selected_; }
-      set {
+      set
+      {
         selected_ = value;
       }
     }
@@ -9658,9 +11053,11 @@ namespace Protobuf.Messages {
     private uint slot_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint Slot {
+    public uint Slot
+    {
       get { return slot_; }
-      set {
+      set
+      {
         slot_ = value;
       }
     }
@@ -9670,9 +11067,11 @@ namespace Protobuf.Messages {
     private string campaignLevelId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string CampaignLevelId {
+    public string CampaignLevelId
+    {
       get { return campaignLevelId_; }
-      set {
+      set
+      {
         campaignLevelId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -9682,9 +11081,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -9694,9 +11095,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Character character_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Character Character {
+    public global::Protobuf.Messages.Character Character
+    {
       get { return character_; }
-      set {
+      set
+      {
         character_ = value;
       }
     }
@@ -9708,23 +11111,28 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Item> items_ = new pbc::RepeatedField<global::Protobuf.Messages.Item>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Item> Items {
+    public pbc::RepeatedField<global::Protobuf.Messages.Item> Items
+    {
       get { return items_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Unit);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Unit other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Unit other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
@@ -9736,13 +11144,14 @@ namespace Protobuf.Messages {
       if (CampaignLevelId != other.CampaignLevelId) return false;
       if (UserId != other.UserId) return false;
       if (!object.Equals(Character, other.Character)) return false;
-      if(!items_.Equals(other.items_)) return false;
+      if (!items_.Equals(other.items_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (Level != 0) hash ^= Level.GetHashCode();
@@ -9754,7 +11163,8 @@ namespace Protobuf.Messages {
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (character_ != null) hash ^= Character.GetHashCode();
       hash ^= items_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -9762,16 +11172,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -9812,89 +11224,111 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (Level != 0) {
+      if (Level != 0)
+      {
         output.WriteRawTag(16);
         output.WriteUInt32(Level);
       }
-      if (Tier != 0) {
+      if (Tier != 0)
+      {
         output.WriteRawTag(24);
         output.WriteUInt32(Tier);
       }
-      if (Rank != 0) {
+      if (Rank != 0)
+      {
         output.WriteRawTag(32);
         output.WriteUInt32(Rank);
       }
-      if (Selected != false) {
+      if (Selected != false)
+      {
         output.WriteRawTag(40);
         output.WriteBool(Selected);
       }
-      if (Slot != 0) {
+      if (Slot != 0)
+      {
         output.WriteRawTag(48);
         output.WriteUInt32(Slot);
       }
-      if (CampaignLevelId.Length != 0) {
+      if (CampaignLevelId.Length != 0)
+      {
         output.WriteRawTag(58);
         output.WriteString(CampaignLevelId);
       }
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(66);
         output.WriteString(UserId);
       }
-      if (character_ != null) {
+      if (character_ != null)
+      {
         output.WriteRawTag(74);
         output.WriteMessage(Character);
       }
       items_.WriteTo(ref output, _repeated_items_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (Level != 0) {
+      if (Level != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Level);
       }
-      if (Tier != 0) {
+      if (Tier != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Tier);
       }
-      if (Rank != 0) {
+      if (Rank != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Rank);
       }
-      if (Selected != false) {
+      if (Selected != false)
+      {
         size += 1 + 1;
       }
-      if (Slot != 0) {
+      if (Slot != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Slot);
       }
-      if (CampaignLevelId.Length != 0) {
+      if (CampaignLevelId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(CampaignLevelId);
       }
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (character_ != null) {
+      if (character_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Character);
       }
       size += items_.CalculateSize(_repeated_items_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -9902,36 +11336,48 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Unit other) {
-      if (other == null) {
+    public void MergeFrom(Unit other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.Level != 0) {
+      if (other.Level != 0)
+      {
         Level = other.Level;
       }
-      if (other.Tier != 0) {
+      if (other.Tier != 0)
+      {
         Tier = other.Tier;
       }
-      if (other.Rank != 0) {
+      if (other.Rank != 0)
+      {
         Rank = other.Rank;
       }
-      if (other.Selected != false) {
+      if (other.Selected != false)
+      {
         Selected = other.Selected;
       }
-      if (other.Slot != 0) {
+      if (other.Slot != 0)
+      {
         Slot = other.Slot;
       }
-      if (other.CampaignLevelId.Length != 0) {
+      if (other.CampaignLevelId.Length != 0)
+      {
         CampaignLevelId = other.CampaignLevelId;
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.character_ != null) {
-        if (character_ == null) {
+      if (other.character_ != null)
+      {
+        if (character_ == null)
+        {
           Character = new global::Protobuf.Messages.Character();
         }
         Character.MergeFrom(other.Character);
@@ -9942,10 +11388,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -9997,74 +11444,88 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 16: {
-            Level = input.ReadUInt32();
-            break;
-          }
-          case 24: {
-            Tier = input.ReadUInt32();
-            break;
-          }
-          case 32: {
-            Rank = input.ReadUInt32();
-            break;
-          }
-          case 40: {
-            Selected = input.ReadBool();
-            break;
-          }
-          case 48: {
-            Slot = input.ReadUInt32();
-            break;
-          }
-          case 58: {
-            CampaignLevelId = input.ReadString();
-            break;
-          }
-          case 66: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 74: {
-            if (character_ == null) {
-              Character = new global::Protobuf.Messages.Character();
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
             }
-            input.ReadMessage(Character);
-            break;
-          }
-          case 82: {
-            items_.AddEntriesFrom(ref input, _repeated_items_codec);
-            break;
-          }
+          case 16:
+            {
+              Level = input.ReadUInt32();
+              break;
+            }
+          case 24:
+            {
+              Tier = input.ReadUInt32();
+              break;
+            }
+          case 32:
+            {
+              Rank = input.ReadUInt32();
+              break;
+            }
+          case 40:
+            {
+              Selected = input.ReadBool();
+              break;
+            }
+          case 48:
+            {
+              Slot = input.ReadUInt32();
+              break;
+            }
+          case 58:
+            {
+              CampaignLevelId = input.ReadString();
+              break;
+            }
+          case 66:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 74:
+            {
+              if (character_ == null)
+              {
+                Character = new global::Protobuf.Messages.Character();
+              }
+              input.ReadMessage(Character);
+              break;
+            }
+          case 82:
+            {
+              items_.AddEntriesFrom(ref input, _repeated_items_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Units : pb::IMessage<Units>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Units> _parser = new pb::MessageParser<Units>(() => new Units());
     private pb::UnknownFieldSet _unknownFields;
@@ -10074,19 +11535,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[33]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Units() {
+    public Units()
+    {
       OnConstruction();
     }
 
@@ -10094,14 +11558,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Units(Units other) : this() {
+    public Units(Units other) : this()
+    {
       units_ = other.units_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Units Clone() {
+    public Units Clone()
+    {
       return new Units(this);
     }
 
@@ -10112,35 +11578,42 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Unit> units_ = new pbc::RepeatedField<global::Protobuf.Messages.Unit>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Unit> Units_ {
+    public pbc::RepeatedField<global::Protobuf.Messages.Unit> Units_
+    {
       get { return units_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Units);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Units other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Units other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
-      if(!units_.Equals(other.units_)) return false;
+      if (!units_.Equals(other.units_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       hash ^= units_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -10148,40 +11621,46 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       units_.WriteTo(output, _repeated_units_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
       units_.WriteTo(ref output, _repeated_units_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
       size += units_.CalculateSize(_repeated_units_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -10189,8 +11668,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Units other) {
-      if (other == null) {
+    public void MergeFrom(Units other)
+    {
+      if (other == null)
+      {
         return;
       }
       units_.Add(other.units_);
@@ -10199,10 +11680,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -10215,35 +11697,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            units_.AddEntriesFrom(ref input, _repeated_units_codec);
-            break;
-          }
+          case 10:
+            {
+              units_.AddEntriesFrom(ref input, _repeated_units_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UnitAndCurrencies : pb::IMessage<UnitAndCurrencies>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<UnitAndCurrencies> _parser = new pb::MessageParser<UnitAndCurrencies>(() => new UnitAndCurrencies());
     private pb::UnknownFieldSet _unknownFields;
@@ -10253,19 +11739,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[34]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnitAndCurrencies() {
+    public UnitAndCurrencies()
+    {
       OnConstruction();
     }
 
@@ -10273,7 +11762,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnitAndCurrencies(UnitAndCurrencies other) : this() {
+    public UnitAndCurrencies(UnitAndCurrencies other) : this()
+    {
       unit_ = other.unit_ != null ? other.unit_.Clone() : null;
       userCurrency_ = other.userCurrency_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -10281,7 +11771,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UnitAndCurrencies Clone() {
+    public UnitAndCurrencies Clone()
+    {
       return new UnitAndCurrencies(this);
     }
 
@@ -10290,9 +11781,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Unit unit_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Unit Unit {
+    public global::Protobuf.Messages.Unit Unit
+    {
       get { return unit_; }
-      set {
+      set
+      {
         unit_ = value;
       }
     }
@@ -10304,37 +11797,44 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.UserCurrency> userCurrency_ = new pbc::RepeatedField<global::Protobuf.Messages.UserCurrency>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.UserCurrency> UserCurrency {
+    public pbc::RepeatedField<global::Protobuf.Messages.UserCurrency> UserCurrency
+    {
       get { return userCurrency_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as UnitAndCurrencies);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(UnitAndCurrencies other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(UnitAndCurrencies other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(Unit, other.Unit)) return false;
-      if(!userCurrency_.Equals(other.userCurrency_)) return false;
+      if (!userCurrency_.Equals(other.userCurrency_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (unit_ != null) hash ^= Unit.GetHashCode();
       hash ^= userCurrency_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -10342,16 +11842,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (unit_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Unit);
@@ -10360,33 +11862,39 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (unit_ != null) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (unit_ != null)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(Unit);
       }
       userCurrency_.WriteTo(ref output, _repeated_userCurrency_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (unit_ != null) {
+      if (unit_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Unit);
       }
       size += userCurrency_.CalculateSize(_repeated_userCurrency_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -10394,12 +11902,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(UnitAndCurrencies other) {
-      if (other == null) {
+    public void MergeFrom(UnitAndCurrencies other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.unit_ != null) {
-        if (unit_ == null) {
+      if (other.unit_ != null)
+      {
+        if (unit_ == null)
+        {
           Unit = new global::Protobuf.Messages.Unit();
         }
         Unit.MergeFrom(other.Unit);
@@ -10410,10 +11922,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -10433,42 +11946,48 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            if (unit_ == null) {
-              Unit = new global::Protobuf.Messages.Unit();
+          case 10:
+            {
+              if (unit_ == null)
+              {
+                Unit = new global::Protobuf.Messages.Unit();
+              }
+              input.ReadMessage(Unit);
+              break;
             }
-            input.ReadMessage(Unit);
-            break;
-          }
-          case 18: {
-            userCurrency_.AddEntriesFrom(ref input, _repeated_userCurrency_codec);
-            break;
-          }
+          case 18:
+            {
+              userCurrency_.AddEntriesFrom(ref input, _repeated_userCurrency_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Character : pb::IMessage<Character>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Character> _parser = new pb::MessageParser<Character>(() => new Character());
     private pb::UnknownFieldSet _unknownFields;
@@ -10478,19 +11997,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[35]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Character() {
+    public Character()
+    {
       OnConstruction();
     }
 
@@ -10498,7 +12020,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Character(Character other) : this() {
+    public Character(Character other) : this()
+    {
       active_ = other.active_;
       name_ = other.name_;
       faction_ = other.faction_;
@@ -10508,7 +12031,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Character Clone() {
+    public Character Clone()
+    {
       return new Character(this);
     }
 
@@ -10517,9 +12041,11 @@ namespace Protobuf.Messages {
     private bool active_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Active {
+    public bool Active
+    {
       get { return active_; }
-      set {
+      set
+      {
         active_ = value;
       }
     }
@@ -10529,9 +12055,11 @@ namespace Protobuf.Messages {
     private string name_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Name {
+    public string Name
+    {
       get { return name_; }
-      set {
+      set
+      {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -10541,9 +12069,11 @@ namespace Protobuf.Messages {
     private string faction_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Faction {
+    public string Faction
+    {
       get { return faction_; }
-      set {
+      set
+      {
         faction_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -10553,26 +12083,32 @@ namespace Protobuf.Messages {
     private uint quality_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint Quality {
+    public uint Quality
+    {
       get { return quality_; }
-      set {
+      set
+      {
         quality_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Character);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Character other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Character other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Active != other.Active) return false;
@@ -10584,13 +12120,15 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Active != false) hash ^= Active.GetHashCode();
       if (Name.Length != 0) hash ^= Name.GetHashCode();
       if (Faction.Length != 0) hash ^= Faction.GetHashCode();
       if (Quality != 0) hash ^= Quality.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -10598,16 +12136,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Active != false) {
         output.WriteRawTag(8);
         output.WriteBool(Active);
@@ -10627,52 +12167,64 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Active != false) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Active != false)
+      {
         output.WriteRawTag(8);
         output.WriteBool(Active);
       }
-      if (Name.Length != 0) {
+      if (Name.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(Name);
       }
-      if (Faction.Length != 0) {
+      if (Faction.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(Faction);
       }
-      if (Quality != 0) {
+      if (Quality != 0)
+      {
         output.WriteRawTag(32);
         output.WriteUInt32(Quality);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Active != false) {
+      if (Active != false)
+      {
         size += 1 + 1;
       }
-      if (Name.Length != 0) {
+      if (Name.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
       }
-      if (Faction.Length != 0) {
+      if (Faction.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Faction);
       }
-      if (Quality != 0) {
+      if (Quality != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Quality);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -10680,20 +12232,26 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Character other) {
-      if (other == null) {
+    public void MergeFrom(Character other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Active != false) {
+      if (other.Active != false)
+      {
         Active = other.Active;
       }
-      if (other.Name.Length != 0) {
+      if (other.Name.Length != 0)
+      {
         Name = other.Name;
       }
-      if (other.Faction.Length != 0) {
+      if (other.Faction.Length != 0)
+      {
         Faction = other.Faction;
       }
-      if (other.Quality != 0) {
+      if (other.Quality != 0)
+      {
         Quality = other.Quality;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -10701,10 +12259,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -10729,47 +12288,54 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 8: {
-            Active = input.ReadBool();
-            break;
-          }
-          case 18: {
-            Name = input.ReadString();
-            break;
-          }
-          case 26: {
-            Faction = input.ReadString();
-            break;
-          }
-          case 32: {
-            Quality = input.ReadUInt32();
-            break;
-          }
+          case 8:
+            {
+              Active = input.ReadBool();
+              break;
+            }
+          case 18:
+            {
+              Name = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              Faction = input.ReadString();
+              break;
+            }
+          case 32:
+            {
+              Quality = input.ReadUInt32();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Item : pb::IMessage<Item>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Item> _parser = new pb::MessageParser<Item>(() => new Item());
     private pb::UnknownFieldSet _unknownFields;
@@ -10779,19 +12345,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[36]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Item() {
+    public Item()
+    {
       OnConstruction();
     }
 
@@ -10799,7 +12368,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Item(Item other) : this() {
+    public Item(Item other) : this()
+    {
       id_ = other.id_;
       level_ = other.level_;
       template_ = other.template_ != null ? other.template_.Clone() : null;
@@ -10810,7 +12380,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Item Clone() {
+    public Item Clone()
+    {
       return new Item(this);
     }
 
@@ -10819,9 +12390,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -10831,9 +12404,11 @@ namespace Protobuf.Messages {
     private uint level_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint Level {
+    public uint Level
+    {
       get { return level_; }
-      set {
+      set
+      {
         level_ = value;
       }
     }
@@ -10843,9 +12418,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.ItemTemplate template_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.ItemTemplate Template {
+    public global::Protobuf.Messages.ItemTemplate Template
+    {
       get { return template_; }
-      set {
+      set
+      {
         template_ = value;
       }
     }
@@ -10855,9 +12432,11 @@ namespace Protobuf.Messages {
     private string userId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UserId {
+    public string UserId
+    {
       get { return userId_; }
-      set {
+      set
+      {
         userId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -10867,26 +12446,32 @@ namespace Protobuf.Messages {
     private string unitId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UnitId {
+    public string UnitId
+    {
       get { return unitId_; }
-      set {
+      set
+      {
         unitId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Item);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Item other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Item other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
@@ -10899,14 +12484,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (Level != 0) hash ^= Level.GetHashCode();
       if (template_ != null) hash ^= Template.GetHashCode();
       if (UserId.Length != 0) hash ^= UserId.GetHashCode();
       if (UnitId.Length != 0) hash ^= UnitId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -10914,16 +12501,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -10947,59 +12536,73 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (Level != 0) {
+      if (Level != 0)
+      {
         output.WriteRawTag(16);
         output.WriteUInt32(Level);
       }
-      if (template_ != null) {
+      if (template_ != null)
+      {
         output.WriteRawTag(26);
         output.WriteMessage(Template);
       }
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         output.WriteRawTag(34);
         output.WriteString(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         output.WriteRawTag(42);
         output.WriteString(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (Level != 0) {
+      if (Level != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(Level);
       }
-      if (template_ != null) {
+      if (template_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Template);
       }
-      if (UserId.Length != 0) {
+      if (UserId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UserId);
       }
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -11007,26 +12610,34 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Item other) {
-      if (other == null) {
+    public void MergeFrom(Item other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.Level != 0) {
+      if (other.Level != 0)
+      {
         Level = other.Level;
       }
-      if (other.template_ != null) {
-        if (template_ == null) {
+      if (other.template_ != null)
+      {
+        if (template_ == null)
+        {
           Template = new global::Protobuf.Messages.ItemTemplate();
         }
         Template.MergeFrom(other.Template);
       }
-      if (other.UserId.Length != 0) {
+      if (other.UserId.Length != 0)
+      {
         UserId = other.UserId;
       }
-      if (other.UnitId.Length != 0) {
+      if (other.UnitId.Length != 0)
+      {
         UnitId = other.UnitId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -11034,10 +12645,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -11069,54 +12681,63 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 16: {
-            Level = input.ReadUInt32();
-            break;
-          }
-          case 26: {
-            if (template_ == null) {
-              Template = new global::Protobuf.Messages.ItemTemplate();
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
             }
-            input.ReadMessage(Template);
-            break;
-          }
-          case 34: {
-            UserId = input.ReadString();
-            break;
-          }
-          case 42: {
-            UnitId = input.ReadString();
-            break;
-          }
+          case 16:
+            {
+              Level = input.ReadUInt32();
+              break;
+            }
+          case 26:
+            {
+              if (template_ == null)
+              {
+                Template = new global::Protobuf.Messages.ItemTemplate();
+              }
+              input.ReadMessage(Template);
+              break;
+            }
+          case 34:
+            {
+              UserId = input.ReadString();
+              break;
+            }
+          case 42:
+            {
+              UnitId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ItemTemplate : pb::IMessage<ItemTemplate>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<ItemTemplate> _parser = new pb::MessageParser<ItemTemplate>(() => new ItemTemplate());
     private pb::UnknownFieldSet _unknownFields;
@@ -11126,19 +12747,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[37]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ItemTemplate() {
+    public ItemTemplate()
+    {
       OnConstruction();
     }
 
@@ -11146,7 +12770,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ItemTemplate(ItemTemplate other) : this() {
+    public ItemTemplate(ItemTemplate other) : this()
+    {
       id_ = other.id_;
       name_ = other.name_;
       type_ = other.type_;
@@ -11155,7 +12780,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ItemTemplate Clone() {
+    public ItemTemplate Clone()
+    {
       return new ItemTemplate(this);
     }
 
@@ -11164,9 +12790,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -11176,9 +12804,11 @@ namespace Protobuf.Messages {
     private string name_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Name {
+    public string Name
+    {
       get { return name_; }
-      set {
+      set
+      {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -11188,26 +12818,32 @@ namespace Protobuf.Messages {
     private string type_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Type {
+    public string Type
+    {
       get { return type_; }
-      set {
+      set
+      {
         type_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as ItemTemplate);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(ItemTemplate other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(ItemTemplate other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
@@ -11218,12 +12854,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (Name.Length != 0) hash ^= Name.GetHashCode();
       if (Type.Length != 0) hash ^= Type.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -11231,16 +12869,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -11256,45 +12896,55 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (Name.Length != 0) {
+      if (Name.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(Name);
       }
-      if (Type.Length != 0) {
+      if (Type.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(Type);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (Name.Length != 0) {
+      if (Name.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
       }
-      if (Type.Length != 0) {
+      if (Type.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Type);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -11302,17 +12952,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(ItemTemplate other) {
-      if (other == null) {
+    public void MergeFrom(ItemTemplate other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.Name.Length != 0) {
+      if (other.Name.Length != 0)
+      {
         Name = other.Name;
       }
-      if (other.Type.Length != 0) {
+      if (other.Type.Length != 0)
+      {
         Type = other.Type;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -11320,10 +12975,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -11344,43 +13000,49 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 18: {
-            Name = input.ReadString();
-            break;
-          }
-          case 26: {
-            Type = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              Name = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              Type = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Campaigns : pb::IMessage<Campaigns>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Campaigns> _parser = new pb::MessageParser<Campaigns>(() => new Campaigns());
     private pb::UnknownFieldSet _unknownFields;
@@ -11390,19 +13052,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[38]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Campaigns() {
+    public Campaigns()
+    {
       OnConstruction();
     }
 
@@ -11410,14 +13075,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Campaigns(Campaigns other) : this() {
+    public Campaigns(Campaigns other) : this()
+    {
       campaigns_ = other.campaigns_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Campaigns Clone() {
+    public Campaigns Clone()
+    {
       return new Campaigns(this);
     }
 
@@ -11428,35 +13095,42 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Campaign> campaigns_ = new pbc::RepeatedField<global::Protobuf.Messages.Campaign>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Campaign> Campaigns_ {
+    public pbc::RepeatedField<global::Protobuf.Messages.Campaign> Campaigns_
+    {
       get { return campaigns_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Campaigns);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Campaigns other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Campaigns other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
-      if(!campaigns_.Equals(other.campaigns_)) return false;
+      if (!campaigns_.Equals(other.campaigns_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       hash ^= campaigns_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -11464,40 +13138,46 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       campaigns_.WriteTo(output, _repeated_campaigns_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
       campaigns_.WriteTo(ref output, _repeated_campaigns_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
       size += campaigns_.CalculateSize(_repeated_campaigns_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -11505,8 +13185,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Campaigns other) {
-      if (other == null) {
+    public void MergeFrom(Campaigns other)
+    {
+      if (other == null)
+      {
         return;
       }
       campaigns_.Add(other.campaigns_);
@@ -11515,10 +13197,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -11531,35 +13214,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            campaigns_.AddEntriesFrom(ref input, _repeated_campaigns_codec);
-            break;
-          }
+          case 10:
+            {
+              campaigns_.AddEntriesFrom(ref input, _repeated_campaigns_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Campaign : pb::IMessage<Campaign>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Campaign> _parser = new pb::MessageParser<Campaign>(() => new Campaign());
     private pb::UnknownFieldSet _unknownFields;
@@ -11569,19 +13256,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[39]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Campaign() {
+    public Campaign()
+    {
       OnConstruction();
     }
 
@@ -11589,7 +13279,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Campaign(Campaign other) : this() {
+    public Campaign(Campaign other) : this()
+    {
       id_ = other.id_;
       superCampaignName_ = other.superCampaignName_;
       campaignNumber_ = other.campaignNumber_;
@@ -11599,7 +13290,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Campaign Clone() {
+    public Campaign Clone()
+    {
       return new Campaign(this);
     }
 
@@ -11608,9 +13300,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -11620,9 +13314,11 @@ namespace Protobuf.Messages {
     private string superCampaignName_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SuperCampaignName {
+    public string SuperCampaignName
+    {
       get { return superCampaignName_; }
-      set {
+      set
+      {
         superCampaignName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -11632,9 +13328,11 @@ namespace Protobuf.Messages {
     private uint campaignNumber_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint CampaignNumber {
+    public uint CampaignNumber
+    {
       get { return campaignNumber_; }
-      set {
+      set
+      {
         campaignNumber_ = value;
       }
     }
@@ -11646,41 +13344,48 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Level> levels_ = new pbc::RepeatedField<global::Protobuf.Messages.Level>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Level> Levels {
+    public pbc::RepeatedField<global::Protobuf.Messages.Level> Levels
+    {
       get { return levels_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Campaign);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Campaign other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Campaign other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
       if (SuperCampaignName != other.SuperCampaignName) return false;
       if (CampaignNumber != other.CampaignNumber) return false;
-      if(!levels_.Equals(other.levels_)) return false;
+      if (!levels_.Equals(other.levels_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (SuperCampaignName.Length != 0) hash ^= SuperCampaignName.GetHashCode();
       if (CampaignNumber != 0) hash ^= CampaignNumber.GetHashCode();
       hash ^= levels_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -11688,16 +13393,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -11714,47 +13421,57 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (SuperCampaignName.Length != 0) {
+      if (SuperCampaignName.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(SuperCampaignName);
       }
-      if (CampaignNumber != 0) {
+      if (CampaignNumber != 0)
+      {
         output.WriteRawTag(24);
         output.WriteUInt32(CampaignNumber);
       }
       levels_.WriteTo(ref output, _repeated_levels_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (SuperCampaignName.Length != 0) {
+      if (SuperCampaignName.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(SuperCampaignName);
       }
-      if (CampaignNumber != 0) {
+      if (CampaignNumber != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(CampaignNumber);
       }
       size += levels_.CalculateSize(_repeated_levels_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -11762,17 +13479,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Campaign other) {
-      if (other == null) {
+    public void MergeFrom(Campaign other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.SuperCampaignName.Length != 0) {
+      if (other.SuperCampaignName.Length != 0)
+      {
         SuperCampaignName = other.SuperCampaignName;
       }
-      if (other.CampaignNumber != 0) {
+      if (other.CampaignNumber != 0)
+      {
         CampaignNumber = other.CampaignNumber;
       }
       levels_.Add(other.levels_);
@@ -11781,10 +13503,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -11809,47 +13532,54 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 18: {
-            SuperCampaignName = input.ReadString();
-            break;
-          }
-          case 24: {
-            CampaignNumber = input.ReadUInt32();
-            break;
-          }
-          case 34: {
-            levels_.AddEntriesFrom(ref input, _repeated_levels_codec);
-            break;
-          }
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              SuperCampaignName = input.ReadString();
+              break;
+            }
+          case 24:
+            {
+              CampaignNumber = input.ReadUInt32();
+              break;
+            }
+          case 34:
+            {
+              levels_.AddEntriesFrom(ref input, _repeated_levels_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Level : pb::IMessage<Level>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Level> _parser = new pb::MessageParser<Level>(() => new Level());
     private pb::UnknownFieldSet _unknownFields;
@@ -11859,19 +13589,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[40]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Level() {
+    public Level()
+    {
       OnConstruction();
     }
 
@@ -11879,7 +13612,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Level(Level other) : this() {
+    public Level(Level other) : this()
+    {
       id_ = other.id_;
       campaignId_ = other.campaignId_;
       levelNumber_ = other.levelNumber_;
@@ -11891,7 +13625,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Level Clone() {
+    public Level Clone()
+    {
       return new Level(this);
     }
 
@@ -11900,9 +13635,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -11912,9 +13649,11 @@ namespace Protobuf.Messages {
     private string campaignId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string CampaignId {
+    public string CampaignId
+    {
       get { return campaignId_; }
-      set {
+      set
+      {
         campaignId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -11924,9 +13663,11 @@ namespace Protobuf.Messages {
     private uint levelNumber_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint LevelNumber {
+    public uint LevelNumber
+    {
       get { return levelNumber_; }
-      set {
+      set
+      {
         levelNumber_ = value;
       }
     }
@@ -11938,7 +13679,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Unit> units_ = new pbc::RepeatedField<global::Protobuf.Messages.Unit>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Unit> Units {
+    public pbc::RepeatedField<global::Protobuf.Messages.Unit> Units
+    {
       get { return units_; }
     }
 
@@ -11949,7 +13691,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.CurrencyReward> currencyRewards_ = new pbc::RepeatedField<global::Protobuf.Messages.CurrencyReward>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.CurrencyReward> CurrencyRewards {
+    public pbc::RepeatedField<global::Protobuf.Messages.CurrencyReward> CurrencyRewards
+    {
       get { return currencyRewards_; }
     }
 
@@ -11958,40 +13701,47 @@ namespace Protobuf.Messages {
     private uint experienceReward_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public uint ExperienceReward {
+    public uint ExperienceReward
+    {
       get { return experienceReward_; }
-      set {
+      set
+      {
         experienceReward_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Level);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Level other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Level other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
       if (CampaignId != other.CampaignId) return false;
       if (LevelNumber != other.LevelNumber) return false;
-      if(!units_.Equals(other.units_)) return false;
-      if(!currencyRewards_.Equals(other.currencyRewards_)) return false;
+      if (!units_.Equals(other.units_)) return false;
+      if (!currencyRewards_.Equals(other.currencyRewards_)) return false;
       if (ExperienceReward != other.ExperienceReward) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (CampaignId.Length != 0) hash ^= CampaignId.GetHashCode();
@@ -11999,7 +13749,8 @@ namespace Protobuf.Messages {
       hash ^= units_.GetHashCode();
       hash ^= currencyRewards_.GetHashCode();
       if (ExperienceReward != 0) hash ^= ExperienceReward.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -12007,16 +13758,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -12038,56 +13791,68 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (CampaignId.Length != 0) {
+      if (CampaignId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(CampaignId);
       }
-      if (LevelNumber != 0) {
+      if (LevelNumber != 0)
+      {
         output.WriteRawTag(24);
         output.WriteUInt32(LevelNumber);
       }
       units_.WriteTo(ref output, _repeated_units_codec);
       currencyRewards_.WriteTo(ref output, _repeated_currencyRewards_codec);
-      if (ExperienceReward != 0) {
+      if (ExperienceReward != 0)
+      {
         output.WriteRawTag(48);
         output.WriteUInt32(ExperienceReward);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (CampaignId.Length != 0) {
+      if (CampaignId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(CampaignId);
       }
-      if (LevelNumber != 0) {
+      if (LevelNumber != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(LevelNumber);
       }
       size += units_.CalculateSize(_repeated_units_codec);
       size += currencyRewards_.CalculateSize(_repeated_currencyRewards_codec);
-      if (ExperienceReward != 0) {
+      if (ExperienceReward != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(ExperienceReward);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -12095,22 +13860,28 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Level other) {
-      if (other == null) {
+    public void MergeFrom(Level other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.CampaignId.Length != 0) {
+      if (other.CampaignId.Length != 0)
+      {
         CampaignId = other.CampaignId;
       }
-      if (other.LevelNumber != 0) {
+      if (other.LevelNumber != 0)
+      {
         LevelNumber = other.LevelNumber;
       }
       units_.Add(other.units_);
       currencyRewards_.Add(other.currencyRewards_);
-      if (other.ExperienceReward != 0) {
+      if (other.ExperienceReward != 0)
+      {
         ExperienceReward = other.ExperienceReward;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -12118,10 +13889,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -12154,55 +13926,64 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 18: {
-            CampaignId = input.ReadString();
-            break;
-          }
-          case 24: {
-            LevelNumber = input.ReadUInt32();
-            break;
-          }
-          case 34: {
-            units_.AddEntriesFrom(ref input, _repeated_units_codec);
-            break;
-          }
-          case 42: {
-            currencyRewards_.AddEntriesFrom(ref input, _repeated_currencyRewards_codec);
-            break;
-          }
-          case 48: {
-            ExperienceReward = input.ReadUInt32();
-            break;
-          }
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              CampaignId = input.ReadString();
+              break;
+            }
+          case 24:
+            {
+              LevelNumber = input.ReadUInt32();
+              break;
+            }
+          case 34:
+            {
+              units_.AddEntriesFrom(ref input, _repeated_units_codec);
+              break;
+            }
+          case 42:
+            {
+              currencyRewards_.AddEntriesFrom(ref input, _repeated_currencyRewards_codec);
+              break;
+            }
+          case 48:
+            {
+              ExperienceReward = input.ReadUInt32();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CurrencyReward : pb::IMessage<CurrencyReward>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<CurrencyReward> _parser = new pb::MessageParser<CurrencyReward>(() => new CurrencyReward());
     private pb::UnknownFieldSet _unknownFields;
@@ -12212,19 +13993,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[41]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CurrencyReward() {
+    public CurrencyReward()
+    {
       OnConstruction();
     }
 
@@ -12232,7 +14016,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CurrencyReward(CurrencyReward other) : this() {
+    public CurrencyReward(CurrencyReward other) : this()
+    {
       currency_ = other.currency_ != null ? other.currency_.Clone() : null;
       amount_ = other.amount_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -12240,7 +14025,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CurrencyReward Clone() {
+    public CurrencyReward Clone()
+    {
       return new CurrencyReward(this);
     }
 
@@ -12249,9 +14035,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Currency currency_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Currency Currency {
+    public global::Protobuf.Messages.Currency Currency
+    {
       get { return currency_; }
-      set {
+      set
+      {
         currency_ = value;
       }
     }
@@ -12261,26 +14049,32 @@ namespace Protobuf.Messages {
     private ulong amount_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ulong Amount {
+    public ulong Amount
+    {
       get { return amount_; }
-      set {
+      set
+      {
         amount_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as CurrencyReward);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(CurrencyReward other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(CurrencyReward other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(Currency, other.Currency)) return false;
@@ -12290,11 +14084,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (currency_ != null) hash ^= Currency.GetHashCode();
       if (Amount != 0UL) hash ^= Amount.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -12302,16 +14098,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (currency_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Currency);
@@ -12323,38 +14121,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (currency_ != null) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (currency_ != null)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(Currency);
       }
-      if (Amount != 0UL) {
+      if (Amount != 0UL)
+      {
         output.WriteRawTag(24);
         output.WriteUInt64(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (currency_ != null) {
+      if (currency_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Currency);
       }
-      if (Amount != 0UL) {
+      if (Amount != 0UL)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt64Size(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -12362,17 +14168,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(CurrencyReward other) {
-      if (other == null) {
+    public void MergeFrom(CurrencyReward other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.currency_ != null) {
-        if (currency_ == null) {
+      if (other.currency_ != null)
+      {
+        if (currency_ == null)
+        {
           Currency = new global::Protobuf.Messages.Currency();
         }
         Currency.MergeFrom(other.Currency);
       }
-      if (other.Amount != 0UL) {
+      if (other.Amount != 0UL)
+      {
         Amount = other.Amount;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -12380,10 +14191,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -12403,42 +14215,48 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            if (currency_ == null) {
-              Currency = new global::Protobuf.Messages.Currency();
+          case 10:
+            {
+              if (currency_ == null)
+              {
+                Currency = new global::Protobuf.Messages.Currency();
+              }
+              input.ReadMessage(Currency);
+              break;
             }
-            input.ReadMessage(Currency);
-            break;
-          }
-          case 24: {
-            Amount = input.ReadUInt64();
-            break;
-          }
+          case 24:
+            {
+              Amount = input.ReadUInt64();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class AfkRewards : pb::IMessage<AfkRewards>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<AfkRewards> _parser = new pb::MessageParser<AfkRewards>(() => new AfkRewards());
     private pb::UnknownFieldSet _unknownFields;
@@ -12448,19 +14266,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[42]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkRewards() {
+    public AfkRewards()
+    {
       OnConstruction();
     }
 
@@ -12468,14 +14289,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkRewards(AfkRewards other) : this() {
+    public AfkRewards(AfkRewards other) : this()
+    {
       afkRewards_ = other.afkRewards_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkRewards Clone() {
+    public AfkRewards Clone()
+    {
       return new AfkRewards(this);
     }
 
@@ -12486,35 +14309,42 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.AfkReward> afkRewards_ = new pbc::RepeatedField<global::Protobuf.Messages.AfkReward>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.AfkReward> AfkRewards_ {
+    public pbc::RepeatedField<global::Protobuf.Messages.AfkReward> AfkRewards_
+    {
       get { return afkRewards_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as AfkRewards);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(AfkRewards other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(AfkRewards other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
-      if(!afkRewards_.Equals(other.afkRewards_)) return false;
+      if (!afkRewards_.Equals(other.afkRewards_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       hash ^= afkRewards_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -12522,40 +14352,46 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       afkRewards_.WriteTo(output, _repeated_afkRewards_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
       afkRewards_.WriteTo(ref output, _repeated_afkRewards_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
       size += afkRewards_.CalculateSize(_repeated_afkRewards_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -12563,8 +14399,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(AfkRewards other) {
-      if (other == null) {
+    public void MergeFrom(AfkRewards other)
+    {
+      if (other == null)
+      {
         return;
       }
       afkRewards_.Add(other.afkRewards_);
@@ -12573,10 +14411,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -12589,35 +14428,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            afkRewards_.AddEntriesFrom(ref input, _repeated_afkRewards_codec);
-            break;
-          }
+          case 10:
+            {
+              afkRewards_.AddEntriesFrom(ref input, _repeated_afkRewards_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class AfkReward : pb::IMessage<AfkReward>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<AfkReward> _parser = new pb::MessageParser<AfkReward>(() => new AfkReward());
     private pb::UnknownFieldSet _unknownFields;
@@ -12627,19 +14470,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[43]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkReward() {
+    public AfkReward()
+    {
       OnConstruction();
     }
 
@@ -12647,7 +14493,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkReward(AfkReward other) : this() {
+    public AfkReward(AfkReward other) : this()
+    {
       currency_ = other.currency_ != null ? other.currency_.Clone() : null;
       amount_ = other.amount_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -12655,7 +14502,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public AfkReward Clone() {
+    public AfkReward Clone()
+    {
       return new AfkReward(this);
     }
 
@@ -12664,9 +14512,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Currency currency_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Currency Currency {
+    public global::Protobuf.Messages.Currency Currency
+    {
       get { return currency_; }
-      set {
+      set
+      {
         currency_ = value;
       }
     }
@@ -12676,26 +14526,32 @@ namespace Protobuf.Messages {
     private ulong amount_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ulong Amount {
+    public ulong Amount
+    {
       get { return amount_; }
-      set {
+      set
+      {
         amount_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as AfkReward);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(AfkReward other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(AfkReward other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(Currency, other.Currency)) return false;
@@ -12705,11 +14561,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (currency_ != null) hash ^= Currency.GetHashCode();
       if (Amount != 0UL) hash ^= Amount.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -12717,16 +14575,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (currency_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Currency);
@@ -12738,38 +14598,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (currency_ != null) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (currency_ != null)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(Currency);
       }
-      if (Amount != 0UL) {
+      if (Amount != 0UL)
+      {
         output.WriteRawTag(16);
         output.WriteUInt64(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (currency_ != null) {
+      if (currency_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Currency);
       }
-      if (Amount != 0UL) {
+      if (Amount != 0UL)
+      {
         size += 1 + pb::CodedOutputStream.ComputeUInt64Size(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -12777,17 +14645,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(AfkReward other) {
-      if (other == null) {
+    public void MergeFrom(AfkReward other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.currency_ != null) {
-        if (currency_ == null) {
+      if (other.currency_ != null)
+      {
+        if (currency_ == null)
+        {
           Currency = new global::Protobuf.Messages.Currency();
         }
         Currency.MergeFrom(other.Currency);
       }
-      if (other.Amount != 0UL) {
+      if (other.Amount != 0UL)
+      {
         Amount = other.Amount;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -12795,10 +14668,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -12818,42 +14692,48 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            if (currency_ == null) {
-              Currency = new global::Protobuf.Messages.Currency();
+          case 10:
+            {
+              if (currency_ == null)
+              {
+                Currency = new global::Protobuf.Messages.Currency();
+              }
+              input.ReadMessage(Currency);
+              break;
             }
-            input.ReadMessage(Currency);
-            break;
-          }
-          case 16: {
-            Amount = input.ReadUInt64();
-            break;
-          }
+          case 16:
+            {
+              Amount = input.ReadUInt64();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Error : pb::IMessage<Error>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Error> _parser = new pb::MessageParser<Error>(() => new Error());
     private pb::UnknownFieldSet _unknownFields;
@@ -12863,19 +14743,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[44]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Error() {
+    public Error()
+    {
       OnConstruction();
     }
 
@@ -12883,14 +14766,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Error(Error other) : this() {
+    public Error(Error other) : this()
+    {
       reason_ = other.reason_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Error Clone() {
+    public Error Clone()
+    {
       return new Error(this);
     }
 
@@ -12899,26 +14784,32 @@ namespace Protobuf.Messages {
     private string reason_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Reason {
+    public string Reason
+    {
       get { return reason_; }
-      set {
+      set
+      {
         reason_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Error);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Error other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Error other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Reason != other.Reason) return false;
@@ -12927,10 +14818,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Reason.Length != 0) hash ^= Reason.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -12938,16 +14831,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Reason.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Reason);
@@ -12955,31 +14850,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Reason.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Reason.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Reason);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Reason.Length != 0) {
+      if (Reason.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Reason);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -12987,11 +14888,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Error other) {
-      if (other == null) {
+    public void MergeFrom(Error other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Reason.Length != 0) {
+      if (other.Reason.Length != 0)
+      {
         Reason = other.Reason;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -12999,10 +14903,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -13015,35 +14920,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Reason = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              Reason = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Boxes : pb::IMessage<Boxes>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Boxes> _parser = new pb::MessageParser<Boxes>(() => new Boxes());
     private pb::UnknownFieldSet _unknownFields;
@@ -13053,19 +14962,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[45]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Boxes() {
+    public Boxes()
+    {
       OnConstruction();
     }
 
@@ -13073,14 +14985,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Boxes(Boxes other) : this() {
+    public Boxes(Boxes other) : this()
+    {
       boxes_ = other.boxes_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Boxes Clone() {
+    public Boxes Clone()
+    {
       return new Boxes(this);
     }
 
@@ -13091,35 +15005,42 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Box> boxes_ = new pbc::RepeatedField<global::Protobuf.Messages.Box>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Box> Boxes_ {
+    public pbc::RepeatedField<global::Protobuf.Messages.Box> Boxes_
+    {
       get { return boxes_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Boxes);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Boxes other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Boxes other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
-      if(!boxes_.Equals(other.boxes_)) return false;
+      if (!boxes_.Equals(other.boxes_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       hash ^= boxes_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -13127,40 +15048,46 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       boxes_.WriteTo(output, _repeated_boxes_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
       boxes_.WriteTo(ref output, _repeated_boxes_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
       size += boxes_.CalculateSize(_repeated_boxes_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -13168,8 +15095,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Boxes other) {
-      if (other == null) {
+    public void MergeFrom(Boxes other)
+    {
+      if (other == null)
+      {
         return;
       }
       boxes_.Add(other.boxes_);
@@ -13178,10 +15107,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -13194,35 +15124,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            boxes_.AddEntriesFrom(ref input, _repeated_boxes_codec);
-            break;
-          }
+          case 10:
+            {
+              boxes_.AddEntriesFrom(ref input, _repeated_boxes_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Box : pb::IMessage<Box>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Box> _parser = new pb::MessageParser<Box>(() => new Box());
     private pb::UnknownFieldSet _unknownFields;
@@ -13232,19 +15166,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[46]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Box() {
+    public Box()
+    {
       OnConstruction();
     }
 
@@ -13252,7 +15189,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Box(Box other) : this() {
+    public Box(Box other) : this()
+    {
       id_ = other.id_;
       name_ = other.name_;
       description_ = other.description_;
@@ -13264,7 +15202,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Box Clone() {
+    public Box Clone()
+    {
       return new Box(this);
     }
 
@@ -13273,9 +15212,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -13285,9 +15226,11 @@ namespace Protobuf.Messages {
     private string name_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Name {
+    public string Name
+    {
       get { return name_; }
-      set {
+      set
+      {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -13297,9 +15240,11 @@ namespace Protobuf.Messages {
     private string description_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Description {
+    public string Description
+    {
       get { return description_; }
-      set {
+      set
+      {
         description_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -13311,7 +15256,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<string> factions_ = new pbc::RepeatedField<string>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<string> Factions {
+    public pbc::RepeatedField<string> Factions
+    {
       get { return factions_; }
     }
 
@@ -13322,7 +15268,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.RankWeights> rankWeights_ = new pbc::RepeatedField<global::Protobuf.Messages.RankWeights>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.RankWeights> RankWeights {
+    public pbc::RepeatedField<global::Protobuf.Messages.RankWeights> RankWeights
+    {
       get { return rankWeights_; }
     }
 
@@ -13333,37 +15280,43 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.CurrencyCost> cost_ = new pbc::RepeatedField<global::Protobuf.Messages.CurrencyCost>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.CurrencyCost> Cost {
+    public pbc::RepeatedField<global::Protobuf.Messages.CurrencyCost> Cost
+    {
       get { return cost_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Box);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Box other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Box other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
       if (Name != other.Name) return false;
       if (Description != other.Description) return false;
-      if(!factions_.Equals(other.factions_)) return false;
-      if(!rankWeights_.Equals(other.rankWeights_)) return false;
-      if(!cost_.Equals(other.cost_)) return false;
+      if (!factions_.Equals(other.factions_)) return false;
+      if (!rankWeights_.Equals(other.rankWeights_)) return false;
+      if (!cost_.Equals(other.cost_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (Name.Length != 0) hash ^= Name.GetHashCode();
@@ -13371,7 +15324,8 @@ namespace Protobuf.Messages {
       hash ^= factions_.GetHashCode();
       hash ^= rankWeights_.GetHashCode();
       hash ^= cost_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -13379,16 +15333,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -13407,51 +15363,61 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (Name.Length != 0) {
+      if (Name.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(Name);
       }
-      if (Description.Length != 0) {
+      if (Description.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(Description);
       }
       factions_.WriteTo(ref output, _repeated_factions_codec);
       rankWeights_.WriteTo(ref output, _repeated_rankWeights_codec);
       cost_.WriteTo(ref output, _repeated_cost_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (Name.Length != 0) {
+      if (Name.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
       }
-      if (Description.Length != 0) {
+      if (Description.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Description);
       }
       size += factions_.CalculateSize(_repeated_factions_codec);
       size += rankWeights_.CalculateSize(_repeated_rankWeights_codec);
       size += cost_.CalculateSize(_repeated_cost_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -13459,17 +15425,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Box other) {
-      if (other == null) {
+    public void MergeFrom(Box other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.Name.Length != 0) {
+      if (other.Name.Length != 0)
+      {
         Name = other.Name;
       }
-      if (other.Description.Length != 0) {
+      if (other.Description.Length != 0)
+      {
         Description = other.Description;
       }
       factions_.Add(other.factions_);
@@ -13480,10 +15451,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -13516,55 +15488,64 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 18: {
-            Name = input.ReadString();
-            break;
-          }
-          case 26: {
-            Description = input.ReadString();
-            break;
-          }
-          case 34: {
-            factions_.AddEntriesFrom(ref input, _repeated_factions_codec);
-            break;
-          }
-          case 42: {
-            rankWeights_.AddEntriesFrom(ref input, _repeated_rankWeights_codec);
-            break;
-          }
-          case 50: {
-            cost_.AddEntriesFrom(ref input, _repeated_cost_codec);
-            break;
-          }
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              Name = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              Description = input.ReadString();
+              break;
+            }
+          case 34:
+            {
+              factions_.AddEntriesFrom(ref input, _repeated_factions_codec);
+              break;
+            }
+          case 42:
+            {
+              rankWeights_.AddEntriesFrom(ref input, _repeated_rankWeights_codec);
+              break;
+            }
+          case 50:
+            {
+              cost_.AddEntriesFrom(ref input, _repeated_cost_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RankWeights : pb::IMessage<RankWeights>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<RankWeights> _parser = new pb::MessageParser<RankWeights>(() => new RankWeights());
     private pb::UnknownFieldSet _unknownFields;
@@ -13574,19 +15555,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[47]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public RankWeights() {
+    public RankWeights()
+    {
       OnConstruction();
     }
 
@@ -13594,7 +15578,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public RankWeights(RankWeights other) : this() {
+    public RankWeights(RankWeights other) : this()
+    {
       rank_ = other.rank_;
       weight_ = other.weight_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -13602,7 +15587,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public RankWeights Clone() {
+    public RankWeights Clone()
+    {
       return new RankWeights(this);
     }
 
@@ -13611,9 +15597,11 @@ namespace Protobuf.Messages {
     private int rank_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Rank {
+    public int Rank
+    {
       get { return rank_; }
-      set {
+      set
+      {
         rank_ = value;
       }
     }
@@ -13623,26 +15611,32 @@ namespace Protobuf.Messages {
     private int weight_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Weight {
+    public int Weight
+    {
       get { return weight_; }
-      set {
+      set
+      {
         weight_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as RankWeights);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(RankWeights other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(RankWeights other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Rank != other.Rank) return false;
@@ -13652,11 +15646,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Rank != 0) hash ^= Rank.GetHashCode();
       if (Weight != 0) hash ^= Weight.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -13664,16 +15660,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Rank != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Rank);
@@ -13685,38 +15683,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Rank != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Rank != 0)
+      {
         output.WriteRawTag(8);
         output.WriteInt32(Rank);
       }
-      if (Weight != 0) {
+      if (Weight != 0)
+      {
         output.WriteRawTag(16);
         output.WriteInt32(Weight);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Rank != 0) {
+      if (Rank != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Rank);
       }
-      if (Weight != 0) {
+      if (Weight != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Weight);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -13724,14 +15730,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(RankWeights other) {
-      if (other == null) {
+    public void MergeFrom(RankWeights other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Rank != 0) {
+      if (other.Rank != 0)
+      {
         Rank = other.Rank;
       }
-      if (other.Weight != 0) {
+      if (other.Weight != 0)
+      {
         Weight = other.Weight;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -13739,10 +15749,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -13759,39 +15770,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 8: {
-            Rank = input.ReadInt32();
-            break;
-          }
-          case 16: {
-            Weight = input.ReadInt32();
-            break;
-          }
+          case 8:
+            {
+              Rank = input.ReadInt32();
+              break;
+            }
+          case 16:
+            {
+              Weight = input.ReadInt32();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CurrencyCost : pb::IMessage<CurrencyCost>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<CurrencyCost> _parser = new pb::MessageParser<CurrencyCost>(() => new CurrencyCost());
     private pb::UnknownFieldSet _unknownFields;
@@ -13801,19 +15817,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[48]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CurrencyCost() {
+    public CurrencyCost()
+    {
       OnConstruction();
     }
 
@@ -13821,7 +15840,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CurrencyCost(CurrencyCost other) : this() {
+    public CurrencyCost(CurrencyCost other) : this()
+    {
       currency_ = other.currency_ != null ? other.currency_.Clone() : null;
       amount_ = other.amount_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -13829,7 +15849,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CurrencyCost Clone() {
+    public CurrencyCost Clone()
+    {
       return new CurrencyCost(this);
     }
 
@@ -13838,9 +15859,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Currency currency_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Currency Currency {
+    public global::Protobuf.Messages.Currency Currency
+    {
       get { return currency_; }
-      set {
+      set
+      {
         currency_ = value;
       }
     }
@@ -13850,26 +15873,32 @@ namespace Protobuf.Messages {
     private int amount_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Amount {
+    public int Amount
+    {
       get { return amount_; }
-      set {
+      set
+      {
         amount_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as CurrencyCost);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(CurrencyCost other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(CurrencyCost other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(Currency, other.Currency)) return false;
@@ -13879,11 +15908,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (currency_ != null) hash ^= Currency.GetHashCode();
       if (Amount != 0) hash ^= Amount.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -13891,16 +15922,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (currency_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Currency);
@@ -13912,38 +15945,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (currency_ != null) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (currency_ != null)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(Currency);
       }
-      if (Amount != 0) {
+      if (Amount != 0)
+      {
         output.WriteRawTag(16);
         output.WriteInt32(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (currency_ != null) {
+      if (currency_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Currency);
       }
-      if (Amount != 0) {
+      if (Amount != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -13951,17 +15992,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(CurrencyCost other) {
-      if (other == null) {
+    public void MergeFrom(CurrencyCost other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.currency_ != null) {
-        if (currency_ == null) {
+      if (other.currency_ != null)
+      {
+        if (currency_ == null)
+        {
           Currency = new global::Protobuf.Messages.Currency();
         }
         Currency.MergeFrom(other.Currency);
       }
-      if (other.Amount != 0) {
+      if (other.Amount != 0)
+      {
         Amount = other.Amount;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -13969,10 +16015,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -13992,42 +16039,48 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            if (currency_ == null) {
-              Currency = new global::Protobuf.Messages.Currency();
+          case 10:
+            {
+              if (currency_ == null)
+              {
+                Currency = new global::Protobuf.Messages.Currency();
+              }
+              input.ReadMessage(Currency);
+              break;
             }
-            input.ReadMessage(Currency);
-            break;
-          }
-          case 16: {
-            Amount = input.ReadInt32();
-            break;
-          }
+          case 16:
+            {
+              Amount = input.ReadInt32();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UserAndUnit : pb::IMessage<UserAndUnit>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<UserAndUnit> _parser = new pb::MessageParser<UserAndUnit>(() => new UserAndUnit());
     private pb::UnknownFieldSet _unknownFields;
@@ -14037,19 +16090,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[49]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UserAndUnit() {
+    public UserAndUnit()
+    {
       OnConstruction();
     }
 
@@ -14057,7 +16113,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UserAndUnit(UserAndUnit other) : this() {
+    public UserAndUnit(UserAndUnit other) : this()
+    {
       user_ = other.user_ != null ? other.user_.Clone() : null;
       unit_ = other.unit_ != null ? other.unit_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -14065,7 +16122,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public UserAndUnit Clone() {
+    public UserAndUnit Clone()
+    {
       return new UserAndUnit(this);
     }
 
@@ -14074,9 +16132,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.User user_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.User User {
+    public global::Protobuf.Messages.User User
+    {
       get { return user_; }
-      set {
+      set
+      {
         user_ = value;
       }
     }
@@ -14086,26 +16146,32 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Unit unit_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Unit Unit {
+    public global::Protobuf.Messages.Unit Unit
+    {
       get { return unit_; }
-      set {
+      set
+      {
         unit_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as UserAndUnit);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(UserAndUnit other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(UserAndUnit other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(User, other.User)) return false;
@@ -14115,11 +16181,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (user_ != null) hash ^= User.GetHashCode();
       if (unit_ != null) hash ^= Unit.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -14127,16 +16195,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (user_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(User);
@@ -14148,38 +16218,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (user_ != null) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (user_ != null)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(User);
       }
-      if (unit_ != null) {
+      if (unit_ != null)
+      {
         output.WriteRawTag(18);
         output.WriteMessage(Unit);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (user_ != null) {
+      if (user_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(User);
       }
-      if (unit_ != null) {
+      if (unit_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Unit);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -14187,18 +16265,24 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(UserAndUnit other) {
-      if (other == null) {
+    public void MergeFrom(UserAndUnit other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.user_ != null) {
-        if (user_ == null) {
+      if (other.user_ != null)
+      {
+        if (user_ == null)
+        {
           User = new global::Protobuf.Messages.User();
         }
         User.MergeFrom(other.User);
       }
-      if (other.unit_ != null) {
-        if (unit_ == null) {
+      if (other.unit_ != null)
+      {
+        if (unit_ == null)
+        {
           Unit = new global::Protobuf.Messages.Unit();
         }
         Unit.MergeFrom(other.Unit);
@@ -14208,10 +16292,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -14234,45 +16319,52 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            if (user_ == null) {
-              User = new global::Protobuf.Messages.User();
+          case 10:
+            {
+              if (user_ == null)
+              {
+                User = new global::Protobuf.Messages.User();
+              }
+              input.ReadMessage(User);
+              break;
             }
-            input.ReadMessage(User);
-            break;
-          }
-          case 18: {
-            if (unit_ == null) {
-              Unit = new global::Protobuf.Messages.Unit();
+          case 18:
+            {
+              if (unit_ == null)
+              {
+                Unit = new global::Protobuf.Messages.Unit();
+              }
+              input.ReadMessage(Unit);
+              break;
             }
-            input.ReadMessage(Unit);
-            break;
-          }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BattleResult : pb::IMessage<BattleResult>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<BattleResult> _parser = new pb::MessageParser<BattleResult>(() => new BattleResult());
     private pb::UnknownFieldSet _unknownFields;
@@ -14282,19 +16374,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[50]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public BattleResult() {
+    public BattleResult()
+    {
       OnConstruction();
     }
 
@@ -14302,7 +16397,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public BattleResult(BattleResult other) : this() {
+    public BattleResult(BattleResult other) : this()
+    {
       initialState_ = other.initialState_ != null ? other.initialState_.Clone() : null;
       steps_ = other.steps_.Clone();
       result_ = other.result_;
@@ -14311,7 +16407,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public BattleResult Clone() {
+    public BattleResult Clone()
+    {
       return new BattleResult(this);
     }
 
@@ -14320,9 +16417,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.State initialState_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.State InitialState {
+    public global::Protobuf.Messages.State InitialState
+    {
       get { return initialState_; }
-      set {
+      set
+      {
         initialState_ = value;
       }
     }
@@ -14334,7 +16433,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Step> steps_ = new pbc::RepeatedField<global::Protobuf.Messages.Step>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Step> Steps {
+    public pbc::RepeatedField<global::Protobuf.Messages.Step> Steps
+    {
       get { return steps_; }
     }
 
@@ -14343,42 +16443,50 @@ namespace Protobuf.Messages {
     private string result_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Result {
+    public string Result
+    {
       get { return result_; }
-      set {
+      set
+      {
         result_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as BattleResult);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(BattleResult other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(BattleResult other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(InitialState, other.InitialState)) return false;
-      if(!steps_.Equals(other.steps_)) return false;
+      if (!steps_.Equals(other.steps_)) return false;
       if (Result != other.Result) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (initialState_ != null) hash ^= InitialState.GetHashCode();
       hash ^= steps_.GetHashCode();
       if (Result.Length != 0) hash ^= Result.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -14386,16 +16494,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (initialState_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(InitialState);
@@ -14408,40 +16518,48 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (initialState_ != null) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (initialState_ != null)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(InitialState);
       }
       steps_.WriteTo(ref output, _repeated_steps_codec);
-      if (Result.Length != 0) {
+      if (Result.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(Result);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (initialState_ != null) {
+      if (initialState_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(InitialState);
       }
       size += steps_.CalculateSize(_repeated_steps_codec);
-      if (Result.Length != 0) {
+      if (Result.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Result);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -14449,18 +16567,23 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(BattleResult other) {
-      if (other == null) {
+    public void MergeFrom(BattleResult other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.initialState_ != null) {
-        if (initialState_ == null) {
+      if (other.initialState_ != null)
+      {
+        if (initialState_ == null)
+        {
           InitialState = new global::Protobuf.Messages.State();
         }
         InitialState.MergeFrom(other.InitialState);
       }
       steps_.Add(other.steps_);
-      if (other.Result.Length != 0) {
+      if (other.Result.Length != 0)
+      {
         Result = other.Result;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -14468,10 +16591,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -14495,46 +16619,53 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            if (initialState_ == null) {
-              InitialState = new global::Protobuf.Messages.State();
+          case 10:
+            {
+              if (initialState_ == null)
+              {
+                InitialState = new global::Protobuf.Messages.State();
+              }
+              input.ReadMessage(InitialState);
+              break;
             }
-            input.ReadMessage(InitialState);
-            break;
-          }
-          case 18: {
-            steps_.AddEntriesFrom(ref input, _repeated_steps_codec);
-            break;
-          }
-          case 26: {
-            Result = input.ReadString();
-            break;
-          }
+          case 18:
+            {
+              steps_.AddEntriesFrom(ref input, _repeated_steps_codec);
+              break;
+            }
+          case 26:
+            {
+              Result = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class State : pb::IMessage<State>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<State> _parser = new pb::MessageParser<State>(() => new State());
     private pb::UnknownFieldSet _unknownFields;
@@ -14544,19 +16675,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[51]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public State() {
+    public State()
+    {
       OnConstruction();
     }
 
@@ -14564,14 +16698,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public State(State other) : this() {
+    public State(State other) : this()
+    {
       units_ = other.units_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public State Clone() {
+    public State Clone()
+    {
       return new State(this);
     }
 
@@ -14582,35 +16718,42 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.BattleUnit> units_ = new pbc::RepeatedField<global::Protobuf.Messages.BattleUnit>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.BattleUnit> Units {
+    public pbc::RepeatedField<global::Protobuf.Messages.BattleUnit> Units
+    {
       get { return units_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as State);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(State other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(State other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
-      if(!units_.Equals(other.units_)) return false;
+      if (!units_.Equals(other.units_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       hash ^= units_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -14618,40 +16761,46 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       units_.WriteTo(output, _repeated_units_codec);
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
       units_.WriteTo(ref output, _repeated_units_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
       size += units_.CalculateSize(_repeated_units_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -14659,8 +16808,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(State other) {
-      if (other == null) {
+    public void MergeFrom(State other)
+    {
+      if (other == null)
+      {
         return;
       }
       units_.Add(other.units_);
@@ -14669,10 +16820,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -14685,35 +16837,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            units_.AddEntriesFrom(ref input, _repeated_units_codec);
-            break;
-          }
+          case 10:
+            {
+              units_.AddEntriesFrom(ref input, _repeated_units_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BattleUnit : pb::IMessage<BattleUnit>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<BattleUnit> _parser = new pb::MessageParser<BattleUnit>(() => new BattleUnit());
     private pb::UnknownFieldSet _unknownFields;
@@ -14723,19 +16879,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[52]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public BattleUnit() {
+    public BattleUnit()
+    {
       OnConstruction();
     }
 
@@ -14743,7 +16902,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public BattleUnit(BattleUnit other) : this() {
+    public BattleUnit(BattleUnit other) : this()
+    {
       id_ = other.id_;
       health_ = other.health_;
       energy_ = other.energy_;
@@ -14755,7 +16915,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public BattleUnit Clone() {
+    public BattleUnit Clone()
+    {
       return new BattleUnit(this);
     }
 
@@ -14764,9 +16925,11 @@ namespace Protobuf.Messages {
     private string id_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Id {
+    public string Id
+    {
       get { return id_; }
-      set {
+      set
+      {
         id_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -14776,9 +16939,11 @@ namespace Protobuf.Messages {
     private int health_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Health {
+    public int Health
+    {
       get { return health_; }
-      set {
+      set
+      {
         health_ = value;
       }
     }
@@ -14788,9 +16953,11 @@ namespace Protobuf.Messages {
     private int energy_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Energy {
+    public int Energy
+    {
       get { return energy_; }
-      set {
+      set
+      {
         energy_ = value;
       }
     }
@@ -14800,9 +16967,11 @@ namespace Protobuf.Messages {
     private int slot_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Slot {
+    public int Slot
+    {
       get { return slot_; }
-      set {
+      set
+      {
         slot_ = value;
       }
     }
@@ -14812,9 +16981,11 @@ namespace Protobuf.Messages {
     private string characterId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string CharacterId {
+    public string CharacterId
+    {
       get { return characterId_; }
-      set {
+      set
+      {
         characterId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -14824,26 +16995,32 @@ namespace Protobuf.Messages {
     private int team_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Team {
+    public int Team
+    {
       get { return team_; }
-      set {
+      set
+      {
         team_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as BattleUnit);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(BattleUnit other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(BattleUnit other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Id != other.Id) return false;
@@ -14857,7 +17034,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Id.Length != 0) hash ^= Id.GetHashCode();
       if (Health != 0) hash ^= Health.GetHashCode();
@@ -14865,7 +17043,8 @@ namespace Protobuf.Messages {
       if (Slot != 0) hash ^= Slot.GetHashCode();
       if (CharacterId.Length != 0) hash ^= CharacterId.GetHashCode();
       if (Team != 0) hash ^= Team.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -14873,16 +17052,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Id.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Id);
@@ -14910,66 +17091,82 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Id.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Id.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(Id);
       }
-      if (Health != 0) {
+      if (Health != 0)
+      {
         output.WriteRawTag(16);
         output.WriteInt32(Health);
       }
-      if (Energy != 0) {
+      if (Energy != 0)
+      {
         output.WriteRawTag(24);
         output.WriteInt32(Energy);
       }
-      if (Slot != 0) {
+      if (Slot != 0)
+      {
         output.WriteRawTag(32);
         output.WriteInt32(Slot);
       }
-      if (CharacterId.Length != 0) {
+      if (CharacterId.Length != 0)
+      {
         output.WriteRawTag(42);
         output.WriteString(CharacterId);
       }
-      if (Team != 0) {
+      if (Team != 0)
+      {
         output.WriteRawTag(48);
         output.WriteInt32(Team);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Id.Length != 0) {
+      if (Id.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Id);
       }
-      if (Health != 0) {
+      if (Health != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Health);
       }
-      if (Energy != 0) {
+      if (Energy != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Energy);
       }
-      if (Slot != 0) {
+      if (Slot != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Slot);
       }
-      if (CharacterId.Length != 0) {
+      if (CharacterId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(CharacterId);
       }
-      if (Team != 0) {
+      if (Team != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(Team);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -14977,26 +17174,34 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(BattleUnit other) {
-      if (other == null) {
+    public void MergeFrom(BattleUnit other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Id.Length != 0) {
+      if (other.Id.Length != 0)
+      {
         Id = other.Id;
       }
-      if (other.Health != 0) {
+      if (other.Health != 0)
+      {
         Health = other.Health;
       }
-      if (other.Energy != 0) {
+      if (other.Energy != 0)
+      {
         Energy = other.Energy;
       }
-      if (other.Slot != 0) {
+      if (other.Slot != 0)
+      {
         Slot = other.Slot;
       }
-      if (other.CharacterId.Length != 0) {
+      if (other.CharacterId.Length != 0)
+      {
         CharacterId = other.CharacterId;
       }
-      if (other.Team != 0) {
+      if (other.Team != 0)
+      {
         Team = other.Team;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -15004,10 +17209,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -15040,55 +17246,64 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            Id = input.ReadString();
-            break;
-          }
-          case 16: {
-            Health = input.ReadInt32();
-            break;
-          }
-          case 24: {
-            Energy = input.ReadInt32();
-            break;
-          }
-          case 32: {
-            Slot = input.ReadInt32();
-            break;
-          }
-          case 42: {
-            CharacterId = input.ReadString();
-            break;
-          }
-          case 48: {
-            Team = input.ReadInt32();
-            break;
-          }
+          case 10:
+            {
+              Id = input.ReadString();
+              break;
+            }
+          case 16:
+            {
+              Health = input.ReadInt32();
+              break;
+            }
+          case 24:
+            {
+              Energy = input.ReadInt32();
+              break;
+            }
+          case 32:
+            {
+              Slot = input.ReadInt32();
+              break;
+            }
+          case 42:
+            {
+              CharacterId = input.ReadString();
+              break;
+            }
+          case 48:
+            {
+              Team = input.ReadInt32();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Step : pb::IMessage<Step>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Step> _parser = new pb::MessageParser<Step>(() => new Step());
     private pb::UnknownFieldSet _unknownFields;
@@ -15098,19 +17313,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[53]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Step() {
+    public Step()
+    {
       OnConstruction();
     }
 
@@ -15118,7 +17336,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Step(Step other) : this() {
+    public Step(Step other) : this()
+    {
       stepNumber_ = other.stepNumber_;
       actions_ = other.actions_.Clone();
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -15126,7 +17345,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Step Clone() {
+    public Step Clone()
+    {
       return new Step(this);
     }
 
@@ -15135,9 +17355,11 @@ namespace Protobuf.Messages {
     private int stepNumber_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int StepNumber {
+    public int StepNumber
+    {
       get { return stepNumber_; }
-      set {
+      set
+      {
         stepNumber_ = value;
       }
     }
@@ -15149,37 +17371,44 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<global::Protobuf.Messages.Action> actions_ = new pbc::RepeatedField<global::Protobuf.Messages.Action>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<global::Protobuf.Messages.Action> Actions {
+    public pbc::RepeatedField<global::Protobuf.Messages.Action> Actions
+    {
       get { return actions_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Step);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Step other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Step other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (StepNumber != other.StepNumber) return false;
-      if(!actions_.Equals(other.actions_)) return false;
+      if (!actions_.Equals(other.actions_)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (StepNumber != 0) hash ^= StepNumber.GetHashCode();
       hash ^= actions_.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -15187,16 +17416,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (StepNumber != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(StepNumber);
@@ -15205,33 +17436,39 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (StepNumber != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (StepNumber != 0)
+      {
         output.WriteRawTag(8);
         output.WriteInt32(StepNumber);
       }
       actions_.WriteTo(ref output, _repeated_actions_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (StepNumber != 0) {
+      if (StepNumber != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(StepNumber);
       }
       size += actions_.CalculateSize(_repeated_actions_codec);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -15239,11 +17476,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Step other) {
-      if (other == null) {
+    public void MergeFrom(Step other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.StepNumber != 0) {
+      if (other.StepNumber != 0)
+      {
         StepNumber = other.StepNumber;
       }
       actions_.Add(other.actions_);
@@ -15252,10 +17492,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -15272,39 +17513,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 8: {
-            StepNumber = input.ReadInt32();
-            break;
-          }
-          case 18: {
-            actions_.AddEntriesFrom(ref input, _repeated_actions_codec);
-            break;
-          }
+          case 8:
+            {
+              StepNumber = input.ReadInt32();
+              break;
+            }
+          case 18:
+            {
+              actions_.AddEntriesFrom(ref input, _repeated_actions_codec);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Action : pb::IMessage<Action>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Action> _parser = new pb::MessageParser<Action>(() => new Action());
     private pb::UnknownFieldSet _unknownFields;
@@ -15314,19 +17560,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[54]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Action() {
+    public Action()
+    {
       OnConstruction();
     }
 
@@ -15334,8 +17583,10 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Action(Action other) : this() {
-      switch (other.ActionTypeCase) {
+    public Action(Action other) : this()
+    {
+      switch (other.ActionTypeCase)
+      {
         case ActionTypeOneofCase.SkillAction:
           SkillAction = other.SkillAction.Clone();
           break;
@@ -15370,7 +17621,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Action Clone() {
+    public Action Clone()
+    {
       return new Action(this);
     }
 
@@ -15378,9 +17630,11 @@ namespace Protobuf.Messages {
     public const int SkillActionFieldNumber = 1;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.SkillAction SkillAction {
-      get { return actionTypeCase_ == ActionTypeOneofCase.SkillAction ? (global::Protobuf.Messages.SkillAction) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.SkillAction SkillAction
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.SkillAction ? (global::Protobuf.Messages.SkillAction)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.SkillAction;
       }
@@ -15390,9 +17644,11 @@ namespace Protobuf.Messages {
     public const int ModifierReceivedFieldNumber = 2;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.ModifierReceived ModifierReceived {
-      get { return actionTypeCase_ == ActionTypeOneofCase.ModifierReceived ? (global::Protobuf.Messages.ModifierReceived) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.ModifierReceived ModifierReceived
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.ModifierReceived ? (global::Protobuf.Messages.ModifierReceived)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.ModifierReceived;
       }
@@ -15402,9 +17658,11 @@ namespace Protobuf.Messages {
     public const int TagReceivedFieldNumber = 3;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.TagReceived TagReceived {
-      get { return actionTypeCase_ == ActionTypeOneofCase.TagReceived ? (global::Protobuf.Messages.TagReceived) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.TagReceived TagReceived
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.TagReceived ? (global::Protobuf.Messages.TagReceived)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.TagReceived;
       }
@@ -15414,9 +17672,11 @@ namespace Protobuf.Messages {
     public const int ModifierExpiredFieldNumber = 4;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.ModifierExpired ModifierExpired {
-      get { return actionTypeCase_ == ActionTypeOneofCase.ModifierExpired ? (global::Protobuf.Messages.ModifierExpired) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.ModifierExpired ModifierExpired
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.ModifierExpired ? (global::Protobuf.Messages.ModifierExpired)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.ModifierExpired;
       }
@@ -15426,9 +17686,11 @@ namespace Protobuf.Messages {
     public const int TagExpiredFieldNumber = 5;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.TagExpired TagExpired {
-      get { return actionTypeCase_ == ActionTypeOneofCase.TagExpired ? (global::Protobuf.Messages.TagExpired) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.TagExpired TagExpired
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.TagExpired ? (global::Protobuf.Messages.TagExpired)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.TagExpired;
       }
@@ -15438,9 +17700,11 @@ namespace Protobuf.Messages {
     public const int DeathFieldNumber = 6;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Death Death {
-      get { return actionTypeCase_ == ActionTypeOneofCase.Death ? (global::Protobuf.Messages.Death) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.Death Death
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.Death ? (global::Protobuf.Messages.Death)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.Death;
       }
@@ -15450,9 +17714,11 @@ namespace Protobuf.Messages {
     public const int ExecutionReceivedFieldNumber = 7;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.ExecutionReceived ExecutionReceived {
-      get { return actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived ? (global::Protobuf.Messages.ExecutionReceived) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.ExecutionReceived ExecutionReceived
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived ? (global::Protobuf.Messages.ExecutionReceived)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.ExecutionReceived;
       }
@@ -15462,9 +17728,11 @@ namespace Protobuf.Messages {
     public const int EnergyRegenFieldNumber = 8;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.EnergyRegen EnergyRegen {
-      get { return actionTypeCase_ == ActionTypeOneofCase.EnergyRegen ? (global::Protobuf.Messages.EnergyRegen) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.EnergyRegen EnergyRegen
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.EnergyRegen ? (global::Protobuf.Messages.EnergyRegen)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.EnergyRegen;
       }
@@ -15474,9 +17742,11 @@ namespace Protobuf.Messages {
     public const int StatOverrideFieldNumber = 9;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.StatOverride StatOverride {
-      get { return actionTypeCase_ == ActionTypeOneofCase.StatOverride ? (global::Protobuf.Messages.StatOverride) actionType_ : null; }
-      set {
+    public global::Protobuf.Messages.StatOverride StatOverride
+    {
+      get { return actionTypeCase_ == ActionTypeOneofCase.StatOverride ? (global::Protobuf.Messages.StatOverride)actionType_ : null; }
+      set
+      {
         actionType_ = value;
         actionTypeCase_ = value == null ? ActionTypeOneofCase.None : ActionTypeOneofCase.StatOverride;
       }
@@ -15484,7 +17754,8 @@ namespace Protobuf.Messages {
 
     private object actionType_;
     /// <summary>Enum of possible cases for the "action_type" oneof.</summary>
-    public enum ActionTypeOneofCase {
+    public enum ActionTypeOneofCase
+    {
       None = 0,
       SkillAction = 1,
       ModifierReceived = 2,
@@ -15499,30 +17770,36 @@ namespace Protobuf.Messages {
     private ActionTypeOneofCase actionTypeCase_ = ActionTypeOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ActionTypeOneofCase ActionTypeCase {
+    public ActionTypeOneofCase ActionTypeCase
+    {
       get { return actionTypeCase_; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void ClearActionType() {
+    public void ClearActionType()
+    {
       actionTypeCase_ = ActionTypeOneofCase.None;
       actionType_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Action);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Action other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Action other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (!object.Equals(SkillAction, other.SkillAction)) return false;
@@ -15540,7 +17817,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (actionTypeCase_ == ActionTypeOneofCase.SkillAction) hash ^= SkillAction.GetHashCode();
       if (actionTypeCase_ == ActionTypeOneofCase.ModifierReceived) hash ^= ModifierReceived.GetHashCode();
@@ -15551,8 +17829,9 @@ namespace Protobuf.Messages {
       if (actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived) hash ^= ExecutionReceived.GetHashCode();
       if (actionTypeCase_ == ActionTypeOneofCase.EnergyRegen) hash ^= EnergyRegen.GetHashCode();
       if (actionTypeCase_ == ActionTypeOneofCase.StatOverride) hash ^= StatOverride.GetHashCode();
-      hash ^= (int) actionTypeCase_;
-      if (_unknownFields != null) {
+      hash ^= (int)actionTypeCase_;
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -15560,16 +17839,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (actionTypeCase_ == ActionTypeOneofCase.SkillAction) {
         output.WriteRawTag(10);
         output.WriteMessage(SkillAction);
@@ -15609,87 +17890,109 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (actionTypeCase_ == ActionTypeOneofCase.SkillAction) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (actionTypeCase_ == ActionTypeOneofCase.SkillAction)
+      {
         output.WriteRawTag(10);
         output.WriteMessage(SkillAction);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.ModifierReceived) {
+      if (actionTypeCase_ == ActionTypeOneofCase.ModifierReceived)
+      {
         output.WriteRawTag(18);
         output.WriteMessage(ModifierReceived);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.TagReceived) {
+      if (actionTypeCase_ == ActionTypeOneofCase.TagReceived)
+      {
         output.WriteRawTag(26);
         output.WriteMessage(TagReceived);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.ModifierExpired) {
+      if (actionTypeCase_ == ActionTypeOneofCase.ModifierExpired)
+      {
         output.WriteRawTag(34);
         output.WriteMessage(ModifierExpired);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.TagExpired) {
+      if (actionTypeCase_ == ActionTypeOneofCase.TagExpired)
+      {
         output.WriteRawTag(42);
         output.WriteMessage(TagExpired);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.Death) {
+      if (actionTypeCase_ == ActionTypeOneofCase.Death)
+      {
         output.WriteRawTag(50);
         output.WriteMessage(Death);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived) {
+      if (actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived)
+      {
         output.WriteRawTag(58);
         output.WriteMessage(ExecutionReceived);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.EnergyRegen) {
+      if (actionTypeCase_ == ActionTypeOneofCase.EnergyRegen)
+      {
         output.WriteRawTag(66);
         output.WriteMessage(EnergyRegen);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.StatOverride) {
+      if (actionTypeCase_ == ActionTypeOneofCase.StatOverride)
+      {
         output.WriteRawTag(74);
         output.WriteMessage(StatOverride);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (actionTypeCase_ == ActionTypeOneofCase.SkillAction) {
+      if (actionTypeCase_ == ActionTypeOneofCase.SkillAction)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(SkillAction);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.ModifierReceived) {
+      if (actionTypeCase_ == ActionTypeOneofCase.ModifierReceived)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ModifierReceived);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.TagReceived) {
+      if (actionTypeCase_ == ActionTypeOneofCase.TagReceived)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(TagReceived);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.ModifierExpired) {
+      if (actionTypeCase_ == ActionTypeOneofCase.ModifierExpired)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ModifierExpired);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.TagExpired) {
+      if (actionTypeCase_ == ActionTypeOneofCase.TagExpired)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(TagExpired);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.Death) {
+      if (actionTypeCase_ == ActionTypeOneofCase.Death)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Death);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived) {
+      if (actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ExecutionReceived);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.EnergyRegen) {
+      if (actionTypeCase_ == ActionTypeOneofCase.EnergyRegen)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(EnergyRegen);
       }
-      if (actionTypeCase_ == ActionTypeOneofCase.StatOverride) {
+      if (actionTypeCase_ == ActionTypeOneofCase.StatOverride)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(StatOverride);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -15697,61 +18000,73 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Action other) {
-      if (other == null) {
+    public void MergeFrom(Action other)
+    {
+      if (other == null)
+      {
         return;
       }
-      switch (other.ActionTypeCase) {
+      switch (other.ActionTypeCase)
+      {
         case ActionTypeOneofCase.SkillAction:
-          if (SkillAction == null) {
+          if (SkillAction == null)
+          {
             SkillAction = new global::Protobuf.Messages.SkillAction();
           }
           SkillAction.MergeFrom(other.SkillAction);
           break;
         case ActionTypeOneofCase.ModifierReceived:
-          if (ModifierReceived == null) {
+          if (ModifierReceived == null)
+          {
             ModifierReceived = new global::Protobuf.Messages.ModifierReceived();
           }
           ModifierReceived.MergeFrom(other.ModifierReceived);
           break;
         case ActionTypeOneofCase.TagReceived:
-          if (TagReceived == null) {
+          if (TagReceived == null)
+          {
             TagReceived = new global::Protobuf.Messages.TagReceived();
           }
           TagReceived.MergeFrom(other.TagReceived);
           break;
         case ActionTypeOneofCase.ModifierExpired:
-          if (ModifierExpired == null) {
+          if (ModifierExpired == null)
+          {
             ModifierExpired = new global::Protobuf.Messages.ModifierExpired();
           }
           ModifierExpired.MergeFrom(other.ModifierExpired);
           break;
         case ActionTypeOneofCase.TagExpired:
-          if (TagExpired == null) {
+          if (TagExpired == null)
+          {
             TagExpired = new global::Protobuf.Messages.TagExpired();
           }
           TagExpired.MergeFrom(other.TagExpired);
           break;
         case ActionTypeOneofCase.Death:
-          if (Death == null) {
+          if (Death == null)
+          {
             Death = new global::Protobuf.Messages.Death();
           }
           Death.MergeFrom(other.Death);
           break;
         case ActionTypeOneofCase.ExecutionReceived:
-          if (ExecutionReceived == null) {
+          if (ExecutionReceived == null)
+          {
             ExecutionReceived = new global::Protobuf.Messages.ExecutionReceived();
           }
           ExecutionReceived.MergeFrom(other.ExecutionReceived);
           break;
         case ActionTypeOneofCase.EnergyRegen:
-          if (EnergyRegen == null) {
+          if (EnergyRegen == null)
+          {
             EnergyRegen = new global::Protobuf.Messages.EnergyRegen();
           }
           EnergyRegen.MergeFrom(other.EnergyRegen);
           break;
         case ActionTypeOneofCase.StatOverride:
-          if (StatOverride == null) {
+          if (StatOverride == null)
+          {
             StatOverride = new global::Protobuf.Messages.StatOverride();
           }
           StatOverride.MergeFrom(other.StatOverride);
@@ -15763,10 +18078,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -15856,112 +18172,133 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            global::Protobuf.Messages.SkillAction subBuilder = new global::Protobuf.Messages.SkillAction();
-            if (actionTypeCase_ == ActionTypeOneofCase.SkillAction) {
-              subBuilder.MergeFrom(SkillAction);
+          case 10:
+            {
+              global::Protobuf.Messages.SkillAction subBuilder = new global::Protobuf.Messages.SkillAction();
+              if (actionTypeCase_ == ActionTypeOneofCase.SkillAction)
+              {
+                subBuilder.MergeFrom(SkillAction);
+              }
+              input.ReadMessage(subBuilder);
+              SkillAction = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            SkillAction = subBuilder;
-            break;
-          }
-          case 18: {
-            global::Protobuf.Messages.ModifierReceived subBuilder = new global::Protobuf.Messages.ModifierReceived();
-            if (actionTypeCase_ == ActionTypeOneofCase.ModifierReceived) {
-              subBuilder.MergeFrom(ModifierReceived);
+          case 18:
+            {
+              global::Protobuf.Messages.ModifierReceived subBuilder = new global::Protobuf.Messages.ModifierReceived();
+              if (actionTypeCase_ == ActionTypeOneofCase.ModifierReceived)
+              {
+                subBuilder.MergeFrom(ModifierReceived);
+              }
+              input.ReadMessage(subBuilder);
+              ModifierReceived = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            ModifierReceived = subBuilder;
-            break;
-          }
-          case 26: {
-            global::Protobuf.Messages.TagReceived subBuilder = new global::Protobuf.Messages.TagReceived();
-            if (actionTypeCase_ == ActionTypeOneofCase.TagReceived) {
-              subBuilder.MergeFrom(TagReceived);
+          case 26:
+            {
+              global::Protobuf.Messages.TagReceived subBuilder = new global::Protobuf.Messages.TagReceived();
+              if (actionTypeCase_ == ActionTypeOneofCase.TagReceived)
+              {
+                subBuilder.MergeFrom(TagReceived);
+              }
+              input.ReadMessage(subBuilder);
+              TagReceived = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            TagReceived = subBuilder;
-            break;
-          }
-          case 34: {
-            global::Protobuf.Messages.ModifierExpired subBuilder = new global::Protobuf.Messages.ModifierExpired();
-            if (actionTypeCase_ == ActionTypeOneofCase.ModifierExpired) {
-              subBuilder.MergeFrom(ModifierExpired);
+          case 34:
+            {
+              global::Protobuf.Messages.ModifierExpired subBuilder = new global::Protobuf.Messages.ModifierExpired();
+              if (actionTypeCase_ == ActionTypeOneofCase.ModifierExpired)
+              {
+                subBuilder.MergeFrom(ModifierExpired);
+              }
+              input.ReadMessage(subBuilder);
+              ModifierExpired = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            ModifierExpired = subBuilder;
-            break;
-          }
-          case 42: {
-            global::Protobuf.Messages.TagExpired subBuilder = new global::Protobuf.Messages.TagExpired();
-            if (actionTypeCase_ == ActionTypeOneofCase.TagExpired) {
-              subBuilder.MergeFrom(TagExpired);
+          case 42:
+            {
+              global::Protobuf.Messages.TagExpired subBuilder = new global::Protobuf.Messages.TagExpired();
+              if (actionTypeCase_ == ActionTypeOneofCase.TagExpired)
+              {
+                subBuilder.MergeFrom(TagExpired);
+              }
+              input.ReadMessage(subBuilder);
+              TagExpired = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            TagExpired = subBuilder;
-            break;
-          }
-          case 50: {
-            global::Protobuf.Messages.Death subBuilder = new global::Protobuf.Messages.Death();
-            if (actionTypeCase_ == ActionTypeOneofCase.Death) {
-              subBuilder.MergeFrom(Death);
+          case 50:
+            {
+              global::Protobuf.Messages.Death subBuilder = new global::Protobuf.Messages.Death();
+              if (actionTypeCase_ == ActionTypeOneofCase.Death)
+              {
+                subBuilder.MergeFrom(Death);
+              }
+              input.ReadMessage(subBuilder);
+              Death = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            Death = subBuilder;
-            break;
-          }
-          case 58: {
-            global::Protobuf.Messages.ExecutionReceived subBuilder = new global::Protobuf.Messages.ExecutionReceived();
-            if (actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived) {
-              subBuilder.MergeFrom(ExecutionReceived);
+          case 58:
+            {
+              global::Protobuf.Messages.ExecutionReceived subBuilder = new global::Protobuf.Messages.ExecutionReceived();
+              if (actionTypeCase_ == ActionTypeOneofCase.ExecutionReceived)
+              {
+                subBuilder.MergeFrom(ExecutionReceived);
+              }
+              input.ReadMessage(subBuilder);
+              ExecutionReceived = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            ExecutionReceived = subBuilder;
-            break;
-          }
-          case 66: {
-            global::Protobuf.Messages.EnergyRegen subBuilder = new global::Protobuf.Messages.EnergyRegen();
-            if (actionTypeCase_ == ActionTypeOneofCase.EnergyRegen) {
-              subBuilder.MergeFrom(EnergyRegen);
+          case 66:
+            {
+              global::Protobuf.Messages.EnergyRegen subBuilder = new global::Protobuf.Messages.EnergyRegen();
+              if (actionTypeCase_ == ActionTypeOneofCase.EnergyRegen)
+              {
+                subBuilder.MergeFrom(EnergyRegen);
+              }
+              input.ReadMessage(subBuilder);
+              EnergyRegen = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            EnergyRegen = subBuilder;
-            break;
-          }
-          case 74: {
-            global::Protobuf.Messages.StatOverride subBuilder = new global::Protobuf.Messages.StatOverride();
-            if (actionTypeCase_ == ActionTypeOneofCase.StatOverride) {
-              subBuilder.MergeFrom(StatOverride);
+          case 74:
+            {
+              global::Protobuf.Messages.StatOverride subBuilder = new global::Protobuf.Messages.StatOverride();
+              if (actionTypeCase_ == ActionTypeOneofCase.StatOverride)
+              {
+                subBuilder.MergeFrom(StatOverride);
+              }
+              input.ReadMessage(subBuilder);
+              StatOverride = subBuilder;
+              break;
             }
-            input.ReadMessage(subBuilder);
-            StatOverride = subBuilder;
-            break;
-          }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class StatAffected : pb::IMessage<StatAffected>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<StatAffected> _parser = new pb::MessageParser<StatAffected>(() => new StatAffected());
     private pb::UnknownFieldSet _unknownFields;
@@ -15971,19 +18308,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[55]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public StatAffected() {
+    public StatAffected()
+    {
       OnConstruction();
     }
 
@@ -15991,7 +18331,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public StatAffected(StatAffected other) : this() {
+    public StatAffected(StatAffected other) : this()
+    {
       stat_ = other.stat_;
       amount_ = other.amount_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -15999,7 +18340,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public StatAffected Clone() {
+    public StatAffected Clone()
+    {
       return new StatAffected(this);
     }
 
@@ -16008,9 +18350,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.Stat stat_ = global::Protobuf.Messages.Stat.Health;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.Stat Stat {
+    public global::Protobuf.Messages.Stat Stat
+    {
       get { return stat_; }
-      set {
+      set
+      {
         stat_ = value;
       }
     }
@@ -16020,26 +18364,32 @@ namespace Protobuf.Messages {
     private float amount_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public float Amount {
+    public float Amount
+    {
       get { return amount_; }
-      set {
+      set
+      {
         amount_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as StatAffected);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(StatAffected other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(StatAffected other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (Stat != other.Stat) return false;
@@ -16049,11 +18399,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (Stat != global::Protobuf.Messages.Stat.Health) hash ^= Stat.GetHashCode();
       if (Amount != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(Amount);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -16061,16 +18413,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (Stat != global::Protobuf.Messages.Stat.Health) {
         output.WriteRawTag(8);
         output.WriteEnum((int) Stat);
@@ -16082,38 +18436,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Stat != global::Protobuf.Messages.Stat.Health) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (Stat != global::Protobuf.Messages.Stat.Health)
+      {
         output.WriteRawTag(8);
-        output.WriteEnum((int) Stat);
+        output.WriteEnum((int)Stat);
       }
-      if (Amount != 0F) {
+      if (Amount != 0F)
+      {
         output.WriteRawTag(21);
         output.WriteFloat(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (Stat != global::Protobuf.Messages.Stat.Health) {
-        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Stat);
+      if (Stat != global::Protobuf.Messages.Stat.Health)
+      {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int)Stat);
       }
-      if (Amount != 0F) {
+      if (Amount != 0F)
+      {
         size += 1 + 4;
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -16121,14 +18483,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(StatAffected other) {
-      if (other == null) {
+    public void MergeFrom(StatAffected other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.Stat != global::Protobuf.Messages.Stat.Health) {
+      if (other.Stat != global::Protobuf.Messages.Stat.Health)
+      {
         Stat = other.Stat;
       }
-      if (other.Amount != 0F) {
+      if (other.Amount != 0F)
+      {
         Amount = other.Amount;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -16136,10 +18502,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -16156,39 +18523,44 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 8: {
-            Stat = (global::Protobuf.Messages.Stat) input.ReadEnum();
-            break;
-          }
-          case 21: {
-            Amount = input.ReadFloat();
-            break;
-          }
+          case 8:
+            {
+              Stat = (global::Protobuf.Messages.Stat)input.ReadEnum();
+              break;
+            }
+          case 21:
+            {
+              Amount = input.ReadFloat();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SkillAction : pb::IMessage<SkillAction>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<SkillAction> _parser = new pb::MessageParser<SkillAction>(() => new SkillAction());
     private pb::UnknownFieldSet _unknownFields;
@@ -16198,19 +18570,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[56]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SkillAction() {
+    public SkillAction()
+    {
       OnConstruction();
     }
 
@@ -16218,7 +18593,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SkillAction(SkillAction other) : this() {
+    public SkillAction(SkillAction other) : this()
+    {
       casterId_ = other.casterId_;
       targetIds_ = other.targetIds_.Clone();
       skillId_ = other.skillId_;
@@ -16228,7 +18604,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public SkillAction Clone() {
+    public SkillAction Clone()
+    {
       return new SkillAction(this);
     }
 
@@ -16237,9 +18614,11 @@ namespace Protobuf.Messages {
     private string casterId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string CasterId {
+    public string CasterId
+    {
       get { return casterId_; }
-      set {
+      set
+      {
         casterId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -16251,7 +18630,8 @@ namespace Protobuf.Messages {
     private readonly pbc::RepeatedField<string> targetIds_ = new pbc::RepeatedField<string>();
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public pbc::RepeatedField<string> TargetIds {
+    public pbc::RepeatedField<string> TargetIds
+    {
       get { return targetIds_; }
     }
 
@@ -16260,9 +18640,11 @@ namespace Protobuf.Messages {
     private string skillId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SkillId {
+    public string SkillId
+    {
       get { return skillId_; }
-      set {
+      set
+      {
         skillId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -16272,30 +18654,36 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.SkillActionType skillActionType_ = global::Protobuf.Messages.SkillActionType.AnimationStart;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.SkillActionType SkillActionType {
+    public global::Protobuf.Messages.SkillActionType SkillActionType
+    {
       get { return skillActionType_; }
-      set {
+      set
+      {
         skillActionType_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as SkillAction);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(SkillAction other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(SkillAction other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (CasterId != other.CasterId) return false;
-      if(!targetIds_.Equals(other.targetIds_)) return false;
+      if (!targetIds_.Equals(other.targetIds_)) return false;
       if (SkillId != other.SkillId) return false;
       if (SkillActionType != other.SkillActionType) return false;
       return Equals(_unknownFields, other._unknownFields);
@@ -16303,13 +18691,15 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (CasterId.Length != 0) hash ^= CasterId.GetHashCode();
       hash ^= targetIds_.GetHashCode();
       if (SkillId.Length != 0) hash ^= SkillId.GetHashCode();
       if (SkillActionType != global::Protobuf.Messages.SkillActionType.AnimationStart) hash ^= SkillActionType.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -16317,16 +18707,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (CasterId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(CasterId);
@@ -16343,47 +18735,57 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (CasterId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (CasterId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(CasterId);
       }
       targetIds_.WriteTo(ref output, _repeated_targetIds_codec);
-      if (SkillId.Length != 0) {
+      if (SkillId.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(SkillId);
       }
-      if (SkillActionType != global::Protobuf.Messages.SkillActionType.AnimationStart) {
+      if (SkillActionType != global::Protobuf.Messages.SkillActionType.AnimationStart)
+      {
         output.WriteRawTag(32);
-        output.WriteEnum((int) SkillActionType);
+        output.WriteEnum((int)SkillActionType);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (CasterId.Length != 0) {
+      if (CasterId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(CasterId);
       }
       size += targetIds_.CalculateSize(_repeated_targetIds_codec);
-      if (SkillId.Length != 0) {
+      if (SkillId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(SkillId);
       }
-      if (SkillActionType != global::Protobuf.Messages.SkillActionType.AnimationStart) {
-        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) SkillActionType);
+      if (SkillActionType != global::Protobuf.Messages.SkillActionType.AnimationStart)
+      {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int)SkillActionType);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -16391,18 +18793,23 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(SkillAction other) {
-      if (other == null) {
+    public void MergeFrom(SkillAction other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.CasterId.Length != 0) {
+      if (other.CasterId.Length != 0)
+      {
         CasterId = other.CasterId;
       }
       targetIds_.Add(other.targetIds_);
-      if (other.SkillId.Length != 0) {
+      if (other.SkillId.Length != 0)
+      {
         SkillId = other.SkillId;
       }
-      if (other.SkillActionType != global::Protobuf.Messages.SkillActionType.AnimationStart) {
+      if (other.SkillActionType != global::Protobuf.Messages.SkillActionType.AnimationStart)
+      {
         SkillActionType = other.SkillActionType;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -16410,10 +18817,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -16438,47 +18846,54 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            CasterId = input.ReadString();
-            break;
-          }
-          case 18: {
-            targetIds_.AddEntriesFrom(ref input, _repeated_targetIds_codec);
-            break;
-          }
-          case 26: {
-            SkillId = input.ReadString();
-            break;
-          }
-          case 32: {
-            SkillActionType = (global::Protobuf.Messages.SkillActionType) input.ReadEnum();
-            break;
-          }
+          case 10:
+            {
+              CasterId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              targetIds_.AddEntriesFrom(ref input, _repeated_targetIds_codec);
+              break;
+            }
+          case 26:
+            {
+              SkillId = input.ReadString();
+              break;
+            }
+          case 32:
+            {
+              SkillActionType = (global::Protobuf.Messages.SkillActionType)input.ReadEnum();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExecutionReceived : pb::IMessage<ExecutionReceived>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<ExecutionReceived> _parser = new pb::MessageParser<ExecutionReceived>(() => new ExecutionReceived());
     private pb::UnknownFieldSet _unknownFields;
@@ -16488,19 +18903,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[57]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ExecutionReceived() {
+    public ExecutionReceived()
+    {
       OnConstruction();
     }
 
@@ -16508,7 +18926,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ExecutionReceived(ExecutionReceived other) : this() {
+    public ExecutionReceived(ExecutionReceived other) : this()
+    {
       targetId_ = other.targetId_;
       statAffected_ = other.statAffected_ != null ? other.statAffected_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -16516,7 +18935,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ExecutionReceived Clone() {
+    public ExecutionReceived Clone()
+    {
       return new ExecutionReceived(this);
     }
 
@@ -16525,9 +18945,11 @@ namespace Protobuf.Messages {
     private string targetId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string TargetId {
+    public string TargetId
+    {
       get { return targetId_; }
-      set {
+      set
+      {
         targetId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -16537,26 +18959,32 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.StatAffected statAffected_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.StatAffected StatAffected {
+    public global::Protobuf.Messages.StatAffected StatAffected
+    {
       get { return statAffected_; }
-      set {
+      set
+      {
         statAffected_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as ExecutionReceived);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(ExecutionReceived other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(ExecutionReceived other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (TargetId != other.TargetId) return false;
@@ -16566,11 +18994,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (TargetId.Length != 0) hash ^= TargetId.GetHashCode();
       if (statAffected_ != null) hash ^= StatAffected.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -16578,16 +19008,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (TargetId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(TargetId);
@@ -16599,38 +19031,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (TargetId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (TargetId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(TargetId);
       }
-      if (statAffected_ != null) {
+      if (statAffected_ != null)
+      {
         output.WriteRawTag(18);
         output.WriteMessage(StatAffected);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(TargetId);
       }
-      if (statAffected_ != null) {
+      if (statAffected_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(StatAffected);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -16638,15 +19078,20 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(ExecutionReceived other) {
-      if (other == null) {
+    public void MergeFrom(ExecutionReceived other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.TargetId.Length != 0) {
+      if (other.TargetId.Length != 0)
+      {
         TargetId = other.TargetId;
       }
-      if (other.statAffected_ != null) {
-        if (statAffected_ == null) {
+      if (other.statAffected_ != null)
+      {
+        if (statAffected_ == null)
+        {
           StatAffected = new global::Protobuf.Messages.StatAffected();
         }
         StatAffected.MergeFrom(other.StatAffected);
@@ -16656,10 +19101,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -16679,42 +19125,48 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            TargetId = input.ReadString();
-            break;
-          }
-          case 18: {
-            if (statAffected_ == null) {
-              StatAffected = new global::Protobuf.Messages.StatAffected();
+          case 10:
+            {
+              TargetId = input.ReadString();
+              break;
             }
-            input.ReadMessage(StatAffected);
-            break;
-          }
+          case 18:
+            {
+              if (statAffected_ == null)
+              {
+                StatAffected = new global::Protobuf.Messages.StatAffected();
+              }
+              input.ReadMessage(StatAffected);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ModifierReceived : pb::IMessage<ModifierReceived>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<ModifierReceived> _parser = new pb::MessageParser<ModifierReceived>(() => new ModifierReceived());
     private pb::UnknownFieldSet _unknownFields;
@@ -16724,19 +19176,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[58]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ModifierReceived() {
+    public ModifierReceived()
+    {
       OnConstruction();
     }
 
@@ -16744,7 +19199,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ModifierReceived(ModifierReceived other) : this() {
+    public ModifierReceived(ModifierReceived other) : this()
+    {
       skillId_ = other.skillId_;
       targetId_ = other.targetId_;
       statAffected_ = other.statAffected_ != null ? other.statAffected_.Clone() : null;
@@ -16754,7 +19210,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ModifierReceived Clone() {
+    public ModifierReceived Clone()
+    {
       return new ModifierReceived(this);
     }
 
@@ -16763,9 +19220,11 @@ namespace Protobuf.Messages {
     private string skillId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SkillId {
+    public string SkillId
+    {
       get { return skillId_; }
-      set {
+      set
+      {
         skillId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -16775,9 +19234,11 @@ namespace Protobuf.Messages {
     private string targetId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string TargetId {
+    public string TargetId
+    {
       get { return targetId_; }
-      set {
+      set
+      {
         targetId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -16787,9 +19248,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.StatAffected statAffected_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.StatAffected StatAffected {
+    public global::Protobuf.Messages.StatAffected StatAffected
+    {
       get { return statAffected_; }
-      set {
+      set
+      {
         statAffected_ = value;
       }
     }
@@ -16799,26 +19262,32 @@ namespace Protobuf.Messages {
     private string operation_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Operation {
+    public string Operation
+    {
       get { return operation_; }
-      set {
+      set
+      {
         operation_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as ModifierReceived);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(ModifierReceived other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(ModifierReceived other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (SkillId != other.SkillId) return false;
@@ -16830,13 +19299,15 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (SkillId.Length != 0) hash ^= SkillId.GetHashCode();
       if (TargetId.Length != 0) hash ^= TargetId.GetHashCode();
       if (statAffected_ != null) hash ^= StatAffected.GetHashCode();
       if (Operation.Length != 0) hash ^= Operation.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -16844,16 +19315,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (SkillId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(SkillId);
@@ -16873,52 +19346,64 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (SkillId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (SkillId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(SkillId);
       }
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(TargetId);
       }
-      if (statAffected_ != null) {
+      if (statAffected_ != null)
+      {
         output.WriteRawTag(26);
         output.WriteMessage(StatAffected);
       }
-      if (Operation.Length != 0) {
+      if (Operation.Length != 0)
+      {
         output.WriteRawTag(34);
         output.WriteString(Operation);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (SkillId.Length != 0) {
+      if (SkillId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(SkillId);
       }
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(TargetId);
       }
-      if (statAffected_ != null) {
+      if (statAffected_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(StatAffected);
       }
-      if (Operation.Length != 0) {
+      if (Operation.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Operation);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -16926,23 +19411,30 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(ModifierReceived other) {
-      if (other == null) {
+    public void MergeFrom(ModifierReceived other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.SkillId.Length != 0) {
+      if (other.SkillId.Length != 0)
+      {
         SkillId = other.SkillId;
       }
-      if (other.TargetId.Length != 0) {
+      if (other.TargetId.Length != 0)
+      {
         TargetId = other.TargetId;
       }
-      if (other.statAffected_ != null) {
-        if (statAffected_ == null) {
+      if (other.statAffected_ != null)
+      {
+        if (statAffected_ == null)
+        {
           StatAffected = new global::Protobuf.Messages.StatAffected();
         }
         StatAffected.MergeFrom(other.StatAffected);
       }
-      if (other.Operation.Length != 0) {
+      if (other.Operation.Length != 0)
+      {
         Operation = other.Operation;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -16950,10 +19442,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -16981,50 +19474,58 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            SkillId = input.ReadString();
-            break;
-          }
-          case 18: {
-            TargetId = input.ReadString();
-            break;
-          }
-          case 26: {
-            if (statAffected_ == null) {
-              StatAffected = new global::Protobuf.Messages.StatAffected();
+          case 10:
+            {
+              SkillId = input.ReadString();
+              break;
             }
-            input.ReadMessage(StatAffected);
-            break;
-          }
-          case 34: {
-            Operation = input.ReadString();
-            break;
-          }
+          case 18:
+            {
+              TargetId = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              if (statAffected_ == null)
+              {
+                StatAffected = new global::Protobuf.Messages.StatAffected();
+              }
+              input.ReadMessage(StatAffected);
+              break;
+            }
+          case 34:
+            {
+              Operation = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class TagReceived : pb::IMessage<TagReceived>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<TagReceived> _parser = new pb::MessageParser<TagReceived>(() => new TagReceived());
     private pb::UnknownFieldSet _unknownFields;
@@ -17034,19 +19535,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[59]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TagReceived() {
+    public TagReceived()
+    {
       OnConstruction();
     }
 
@@ -17054,7 +19558,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TagReceived(TagReceived other) : this() {
+    public TagReceived(TagReceived other) : this()
+    {
       skillId_ = other.skillId_;
       targetId_ = other.targetId_;
       tag_ = other.tag_;
@@ -17063,7 +19568,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TagReceived Clone() {
+    public TagReceived Clone()
+    {
       return new TagReceived(this);
     }
 
@@ -17072,9 +19578,11 @@ namespace Protobuf.Messages {
     private string skillId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SkillId {
+    public string SkillId
+    {
       get { return skillId_; }
-      set {
+      set
+      {
         skillId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -17084,9 +19592,11 @@ namespace Protobuf.Messages {
     private string targetId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string TargetId {
+    public string TargetId
+    {
       get { return targetId_; }
-      set {
+      set
+      {
         targetId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -17096,26 +19606,32 @@ namespace Protobuf.Messages {
     private string tag_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Tag {
+    public string Tag
+    {
       get { return tag_; }
-      set {
+      set
+      {
         tag_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as TagReceived);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(TagReceived other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(TagReceived other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (SkillId != other.SkillId) return false;
@@ -17126,12 +19642,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (SkillId.Length != 0) hash ^= SkillId.GetHashCode();
       if (TargetId.Length != 0) hash ^= TargetId.GetHashCode();
       if (Tag.Length != 0) hash ^= Tag.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -17139,16 +19657,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (SkillId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(SkillId);
@@ -17164,45 +19684,55 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (SkillId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (SkillId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(SkillId);
       }
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(TargetId);
       }
-      if (Tag.Length != 0) {
+      if (Tag.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(Tag);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (SkillId.Length != 0) {
+      if (SkillId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(SkillId);
       }
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(TargetId);
       }
-      if (Tag.Length != 0) {
+      if (Tag.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Tag);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -17210,17 +19740,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(TagReceived other) {
-      if (other == null) {
+    public void MergeFrom(TagReceived other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.SkillId.Length != 0) {
+      if (other.SkillId.Length != 0)
+      {
         SkillId = other.SkillId;
       }
-      if (other.TargetId.Length != 0) {
+      if (other.TargetId.Length != 0)
+      {
         TargetId = other.TargetId;
       }
-      if (other.Tag.Length != 0) {
+      if (other.Tag.Length != 0)
+      {
         Tag = other.Tag;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -17228,10 +19763,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -17252,43 +19788,49 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            SkillId = input.ReadString();
-            break;
-          }
-          case 18: {
-            TargetId = input.ReadString();
-            break;
-          }
-          case 26: {
-            Tag = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              SkillId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              TargetId = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              Tag = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ModifierExpired : pb::IMessage<ModifierExpired>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<ModifierExpired> _parser = new pb::MessageParser<ModifierExpired>(() => new ModifierExpired());
     private pb::UnknownFieldSet _unknownFields;
@@ -17298,19 +19840,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[60]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ModifierExpired() {
+    public ModifierExpired()
+    {
       OnConstruction();
     }
 
@@ -17318,7 +19863,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ModifierExpired(ModifierExpired other) : this() {
+    public ModifierExpired(ModifierExpired other) : this()
+    {
       skillId_ = other.skillId_;
       targetId_ = other.targetId_;
       statAffected_ = other.statAffected_ != null ? other.statAffected_.Clone() : null;
@@ -17328,7 +19874,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ModifierExpired Clone() {
+    public ModifierExpired Clone()
+    {
       return new ModifierExpired(this);
     }
 
@@ -17337,9 +19884,11 @@ namespace Protobuf.Messages {
     private string skillId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SkillId {
+    public string SkillId
+    {
       get { return skillId_; }
-      set {
+      set
+      {
         skillId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -17349,9 +19898,11 @@ namespace Protobuf.Messages {
     private string targetId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string TargetId {
+    public string TargetId
+    {
       get { return targetId_; }
-      set {
+      set
+      {
         targetId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -17361,9 +19912,11 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.StatAffected statAffected_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.StatAffected StatAffected {
+    public global::Protobuf.Messages.StatAffected StatAffected
+    {
       get { return statAffected_; }
-      set {
+      set
+      {
         statAffected_ = value;
       }
     }
@@ -17373,26 +19926,32 @@ namespace Protobuf.Messages {
     private string operation_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Operation {
+    public string Operation
+    {
       get { return operation_; }
-      set {
+      set
+      {
         operation_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as ModifierExpired);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(ModifierExpired other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(ModifierExpired other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (SkillId != other.SkillId) return false;
@@ -17404,13 +19963,15 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (SkillId.Length != 0) hash ^= SkillId.GetHashCode();
       if (TargetId.Length != 0) hash ^= TargetId.GetHashCode();
       if (statAffected_ != null) hash ^= StatAffected.GetHashCode();
       if (Operation.Length != 0) hash ^= Operation.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -17418,16 +19979,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (SkillId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(SkillId);
@@ -17447,52 +20010,64 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (SkillId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (SkillId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(SkillId);
       }
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(TargetId);
       }
-      if (statAffected_ != null) {
+      if (statAffected_ != null)
+      {
         output.WriteRawTag(26);
         output.WriteMessage(StatAffected);
       }
-      if (Operation.Length != 0) {
+      if (Operation.Length != 0)
+      {
         output.WriteRawTag(34);
         output.WriteString(Operation);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (SkillId.Length != 0) {
+      if (SkillId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(SkillId);
       }
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(TargetId);
       }
-      if (statAffected_ != null) {
+      if (statAffected_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(StatAffected);
       }
-      if (Operation.Length != 0) {
+      if (Operation.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Operation);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -17500,23 +20075,30 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(ModifierExpired other) {
-      if (other == null) {
+    public void MergeFrom(ModifierExpired other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.SkillId.Length != 0) {
+      if (other.SkillId.Length != 0)
+      {
         SkillId = other.SkillId;
       }
-      if (other.TargetId.Length != 0) {
+      if (other.TargetId.Length != 0)
+      {
         TargetId = other.TargetId;
       }
-      if (other.statAffected_ != null) {
-        if (statAffected_ == null) {
+      if (other.statAffected_ != null)
+      {
+        if (statAffected_ == null)
+        {
           StatAffected = new global::Protobuf.Messages.StatAffected();
         }
         StatAffected.MergeFrom(other.StatAffected);
       }
-      if (other.Operation.Length != 0) {
+      if (other.Operation.Length != 0)
+      {
         Operation = other.Operation;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -17524,10 +20106,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -17555,50 +20138,58 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            SkillId = input.ReadString();
-            break;
-          }
-          case 18: {
-            TargetId = input.ReadString();
-            break;
-          }
-          case 26: {
-            if (statAffected_ == null) {
-              StatAffected = new global::Protobuf.Messages.StatAffected();
+          case 10:
+            {
+              SkillId = input.ReadString();
+              break;
             }
-            input.ReadMessage(StatAffected);
-            break;
-          }
-          case 34: {
-            Operation = input.ReadString();
-            break;
-          }
+          case 18:
+            {
+              TargetId = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              if (statAffected_ == null)
+              {
+                StatAffected = new global::Protobuf.Messages.StatAffected();
+              }
+              input.ReadMessage(StatAffected);
+              break;
+            }
+          case 34:
+            {
+              Operation = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class TagExpired : pb::IMessage<TagExpired>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<TagExpired> _parser = new pb::MessageParser<TagExpired>(() => new TagExpired());
     private pb::UnknownFieldSet _unknownFields;
@@ -17608,19 +20199,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[61]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TagExpired() {
+    public TagExpired()
+    {
       OnConstruction();
     }
 
@@ -17628,7 +20222,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TagExpired(TagExpired other) : this() {
+    public TagExpired(TagExpired other) : this()
+    {
       skillId_ = other.skillId_;
       targetId_ = other.targetId_;
       tag_ = other.tag_;
@@ -17637,7 +20232,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public TagExpired Clone() {
+    public TagExpired Clone()
+    {
       return new TagExpired(this);
     }
 
@@ -17646,9 +20242,11 @@ namespace Protobuf.Messages {
     private string skillId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SkillId {
+    public string SkillId
+    {
       get { return skillId_; }
-      set {
+      set
+      {
         skillId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -17658,9 +20256,11 @@ namespace Protobuf.Messages {
     private string targetId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string TargetId {
+    public string TargetId
+    {
       get { return targetId_; }
-      set {
+      set
+      {
         targetId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -17670,26 +20270,32 @@ namespace Protobuf.Messages {
     private string tag_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Tag {
+    public string Tag
+    {
       get { return tag_; }
-      set {
+      set
+      {
         tag_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as TagExpired);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(TagExpired other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(TagExpired other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (SkillId != other.SkillId) return false;
@@ -17700,12 +20306,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (SkillId.Length != 0) hash ^= SkillId.GetHashCode();
       if (TargetId.Length != 0) hash ^= TargetId.GetHashCode();
       if (Tag.Length != 0) hash ^= Tag.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -17713,16 +20321,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (SkillId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(SkillId);
@@ -17738,45 +20348,55 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (SkillId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (SkillId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(SkillId);
       }
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(TargetId);
       }
-      if (Tag.Length != 0) {
+      if (Tag.Length != 0)
+      {
         output.WriteRawTag(26);
         output.WriteString(Tag);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (SkillId.Length != 0) {
+      if (SkillId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(SkillId);
       }
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(TargetId);
       }
-      if (Tag.Length != 0) {
+      if (Tag.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Tag);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -17784,17 +20404,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(TagExpired other) {
-      if (other == null) {
+    public void MergeFrom(TagExpired other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.SkillId.Length != 0) {
+      if (other.SkillId.Length != 0)
+      {
         SkillId = other.SkillId;
       }
-      if (other.TargetId.Length != 0) {
+      if (other.TargetId.Length != 0)
+      {
         TargetId = other.TargetId;
       }
-      if (other.Tag.Length != 0) {
+      if (other.Tag.Length != 0)
+      {
         Tag = other.Tag;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -17802,10 +20427,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -17826,43 +20452,49 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            SkillId = input.ReadString();
-            break;
-          }
-          case 18: {
-            TargetId = input.ReadString();
-            break;
-          }
-          case 26: {
-            Tag = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              SkillId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              TargetId = input.ReadString();
+              break;
+            }
+          case 26:
+            {
+              Tag = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Death : pb::IMessage<Death>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<Death> _parser = new pb::MessageParser<Death>(() => new Death());
     private pb::UnknownFieldSet _unknownFields;
@@ -17872,19 +20504,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[62]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Death() {
+    public Death()
+    {
       OnConstruction();
     }
 
@@ -17892,14 +20527,16 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Death(Death other) : this() {
+    public Death(Death other) : this()
+    {
       unitId_ = other.unitId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public Death Clone() {
+    public Death Clone()
+    {
       return new Death(this);
     }
 
@@ -17908,26 +20545,32 @@ namespace Protobuf.Messages {
     private string unitId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string UnitId {
+    public string UnitId
+    {
       get { return unitId_; }
-      set {
+      set
+      {
         unitId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as Death);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(Death other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(Death other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (UnitId != other.UnitId) return false;
@@ -17936,10 +20579,12 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (UnitId.Length != 0) hash ^= UnitId.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -17947,16 +20592,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (UnitId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(UnitId);
@@ -17964,31 +20611,37 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (UnitId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (UnitId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (UnitId.Length != 0) {
+      if (UnitId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(UnitId);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -17996,11 +20649,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(Death other) {
-      if (other == null) {
+    public void MergeFrom(Death other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.UnitId.Length != 0) {
+      if (other.UnitId.Length != 0)
+      {
         UnitId = other.UnitId;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -18008,10 +20664,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -18024,35 +20681,39 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            UnitId = input.ReadString();
-            break;
-          }
+          case 10:
+            {
+              UnitId = input.ReadString();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class EnergyRegen : pb::IMessage<EnergyRegen>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<EnergyRegen> _parser = new pb::MessageParser<EnergyRegen>(() => new EnergyRegen());
     private pb::UnknownFieldSet _unknownFields;
@@ -18062,19 +20723,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[63]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public EnergyRegen() {
+    public EnergyRegen()
+    {
       OnConstruction();
     }
 
@@ -18082,7 +20746,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public EnergyRegen(EnergyRegen other) : this() {
+    public EnergyRegen(EnergyRegen other) : this()
+    {
       targetId_ = other.targetId_;
       skillId_ = other.skillId_;
       amount_ = other.amount_;
@@ -18091,7 +20756,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public EnergyRegen Clone() {
+    public EnergyRegen Clone()
+    {
       return new EnergyRegen(this);
     }
 
@@ -18100,9 +20766,11 @@ namespace Protobuf.Messages {
     private string targetId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string TargetId {
+    public string TargetId
+    {
       get { return targetId_; }
-      set {
+      set
+      {
         targetId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -18112,9 +20780,11 @@ namespace Protobuf.Messages {
     private string skillId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string SkillId {
+    public string SkillId
+    {
       get { return skillId_; }
-      set {
+      set
+      {
         skillId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -18124,26 +20794,32 @@ namespace Protobuf.Messages {
     private float amount_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public float Amount {
+    public float Amount
+    {
       get { return amount_; }
-      set {
+      set
+      {
         amount_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as EnergyRegen);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(EnergyRegen other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(EnergyRegen other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (TargetId != other.TargetId) return false;
@@ -18154,12 +20830,14 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (TargetId.Length != 0) hash ^= TargetId.GetHashCode();
       if (SkillId.Length != 0) hash ^= SkillId.GetHashCode();
       if (Amount != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(Amount);
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -18167,16 +20845,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (TargetId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(TargetId);
@@ -18192,45 +20872,55 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (TargetId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (TargetId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(TargetId);
       }
-      if (SkillId.Length != 0) {
+      if (SkillId.Length != 0)
+      {
         output.WriteRawTag(18);
         output.WriteString(SkillId);
       }
-      if (Amount != 0F) {
+      if (Amount != 0F)
+      {
         output.WriteRawTag(29);
         output.WriteFloat(Amount);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(TargetId);
       }
-      if (SkillId.Length != 0) {
+      if (SkillId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(SkillId);
       }
-      if (Amount != 0F) {
+      if (Amount != 0F)
+      {
         size += 1 + 4;
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -18238,17 +20928,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(EnergyRegen other) {
-      if (other == null) {
+    public void MergeFrom(EnergyRegen other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.TargetId.Length != 0) {
+      if (other.TargetId.Length != 0)
+      {
         TargetId = other.TargetId;
       }
-      if (other.SkillId.Length != 0) {
+      if (other.SkillId.Length != 0)
+      {
         SkillId = other.SkillId;
       }
-      if (other.Amount != 0F) {
+      if (other.Amount != 0F)
+      {
         Amount = other.Amount;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -18256,10 +20951,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -18280,43 +20976,49 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            TargetId = input.ReadString();
-            break;
-          }
-          case 18: {
-            SkillId = input.ReadString();
-            break;
-          }
-          case 29: {
-            Amount = input.ReadFloat();
-            break;
-          }
+          case 10:
+            {
+              TargetId = input.ReadString();
+              break;
+            }
+          case 18:
+            {
+              SkillId = input.ReadString();
+              break;
+            }
+          case 29:
+            {
+              Amount = input.ReadFloat();
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class StatOverride : pb::IMessage<StatOverride>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
-  #endif
+#endif
   {
     private static readonly pb::MessageParser<StatOverride> _parser = new pb::MessageParser<StatOverride>(() => new StatOverride());
     private pb::UnknownFieldSet _unknownFields;
@@ -18326,19 +21028,22 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
+    public static pbr::MessageDescriptor Descriptor
+    {
       get { return global::Protobuf.Messages.GatewayReflection.Descriptor.MessageTypes[64]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
+    pbr::MessageDescriptor pb::IMessage.Descriptor
+    {
       get { return Descriptor; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public StatOverride() {
+    public StatOverride()
+    {
       OnConstruction();
     }
 
@@ -18346,7 +21051,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public StatOverride(StatOverride other) : this() {
+    public StatOverride(StatOverride other) : this()
+    {
       targetId_ = other.targetId_;
       statAffected_ = other.statAffected_ != null ? other.statAffected_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -18354,7 +21060,8 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public StatOverride Clone() {
+    public StatOverride Clone()
+    {
       return new StatOverride(this);
     }
 
@@ -18363,9 +21070,11 @@ namespace Protobuf.Messages {
     private string targetId_ = "";
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string TargetId {
+    public string TargetId
+    {
       get { return targetId_; }
-      set {
+      set
+      {
         targetId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
@@ -18375,26 +21084,32 @@ namespace Protobuf.Messages {
     private global::Protobuf.Messages.StatAffected statAffected_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Protobuf.Messages.StatAffected StatAffected {
+    public global::Protobuf.Messages.StatAffected StatAffected
+    {
       get { return statAffected_; }
-      set {
+      set
+      {
         statAffected_ = value;
       }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
+    public override bool Equals(object other)
+    {
       return Equals(other as StatOverride);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(StatOverride other) {
-      if (ReferenceEquals(other, null)) {
+    public bool Equals(StatOverride other)
+    {
+      if (ReferenceEquals(other, null))
+      {
         return false;
       }
-      if (ReferenceEquals(other, this)) {
+      if (ReferenceEquals(other, this))
+      {
         return true;
       }
       if (TargetId != other.TargetId) return false;
@@ -18404,11 +21119,13 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
+    public override int GetHashCode()
+    {
       int hash = 1;
       if (TargetId.Length != 0) hash ^= TargetId.GetHashCode();
       if (statAffected_ != null) hash ^= StatAffected.GetHashCode();
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         hash ^= _unknownFields.GetHashCode();
       }
       return hash;
@@ -18416,16 +21133,18 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
+    public override string ToString()
+    {
       return pb::JsonFormatter.ToDiagnosticString(this);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void WriteTo(pb::CodedOutputStream output)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
-    #else
+#else
       if (TargetId.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(TargetId);
@@ -18437,38 +21156,46 @@ namespace Protobuf.Messages {
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (TargetId.Length != 0) {
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output)
+    {
+      if (TargetId.Length != 0)
+      {
         output.WriteRawTag(10);
         output.WriteString(TargetId);
       }
-      if (statAffected_ != null) {
+      if (statAffected_ != null)
+      {
         output.WriteRawTag(18);
         output.WriteMessage(StatAffected);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         _unknownFields.WriteTo(ref output);
       }
     }
-    #endif
+#endif
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
+    public int CalculateSize()
+    {
       int size = 0;
-      if (TargetId.Length != 0) {
+      if (TargetId.Length != 0)
+      {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(TargetId);
       }
-      if (statAffected_ != null) {
+      if (statAffected_ != null)
+      {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(StatAffected);
       }
-      if (_unknownFields != null) {
+      if (_unknownFields != null)
+      {
         size += _unknownFields.CalculateSize();
       }
       return size;
@@ -18476,15 +21203,20 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(StatOverride other) {
-      if (other == null) {
+    public void MergeFrom(StatOverride other)
+    {
+      if (other == null)
+      {
         return;
       }
-      if (other.TargetId.Length != 0) {
+      if (other.TargetId.Length != 0)
+      {
         TargetId = other.TargetId;
       }
-      if (other.statAffected_ != null) {
-        if (statAffected_ == null) {
+      if (other.statAffected_ != null)
+      {
+        if (statAffected_ == null)
+        {
           StatAffected = new global::Protobuf.Messages.StatAffected();
         }
         StatAffected.MergeFrom(other.StatAffected);
@@ -18494,10 +21226,11 @@ namespace Protobuf.Messages {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    public void MergeFrom(pb::CodedInputStream input)
+    {
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       input.ReadRawMessage(this);
-    #else
+#else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
         switch(tag) {
@@ -18517,34 +21250,40 @@ namespace Protobuf.Messages {
           }
         }
       }
-    #endif
+#endif
     }
 
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+#if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input)
+    {
       uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      while ((tag = input.ReadTag()) != 0)
+      {
+        switch (tag)
+        {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 10: {
-            TargetId = input.ReadString();
-            break;
-          }
-          case 18: {
-            if (statAffected_ == null) {
-              StatAffected = new global::Protobuf.Messages.StatAffected();
+          case 10:
+            {
+              TargetId = input.ReadString();
+              break;
             }
-            input.ReadMessage(StatAffected);
-            break;
-          }
+          case 18:
+            {
+              if (statAffected_ == null)
+              {
+                StatAffected = new global::Protobuf.Messages.StatAffected();
+              }
+              input.ReadMessage(StatAffected);
+              break;
+            }
         }
       }
     }
-    #endif
+#endif
 
   }
 

--- a/gateway.proto
+++ b/gateway.proto
@@ -194,7 +194,7 @@ option csharp_namespace = "Protobuf.Messages";
   message AfkRewardRate {
     string kaline_tree_level_id = 1;
     Currency currency = 2;
-    float rate = 3;
+    float daily_rate = 3;
   }
 
   message UserCurrency {


### PR DESCRIPTION
To be merged with https://github.com/lambdaclass/mirra_backend/pull/668

## Motivation

Updates protobuf messages to sync them with the backend PR

## Summary of changes

Rename protobuf message, inner class and all occurrences of rate to daily_rate

## How has this been tested?

Go through a basic game loop through the client.