### PR TITLE
[GH-263] Fix tier up

### DIFF
--- a/client/Assets/Scenes/UnitDetail.unity
+++ b/client/Assets/Scenes/UnitDetail.unity
@@ -123,6 +123,135 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &672664
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 149551488}
+    m_Modifications:
+    - target: {fileID: 6858262836634528697, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_text
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 408.7149
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624501, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_Name
+      value: GoldLevelUpCost
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836918322556, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f220907786fd84af7a0a1292ce920468, type: 3}
+    - target: {fileID: 6858262836918322557, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836918322557, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 40
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+--- !u!224 &672665 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+  m_PrefabInstance: {fileID: 672664}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &672666 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6858262836634528697, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+  m_PrefabInstance: {fileID: 672664}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &43041520
 GameObject:
   m_ObjectHideFlags: 0
@@ -422,6 +551,69 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 97203767}
   m_CullTransparentMesh: 0
+--- !u!1 &149551487
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 149551488}
+  - component: {fileID: 149551489}
+  m_Layer: 5
+  m_Name: Costs
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &149551488
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 149551487}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 672665}
+  - {fileID: 780785343}
+  m_Father: {fileID: 1680039525}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 166}
+  m_SizeDelta: {x: 88.74304, y: 0}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &149551489
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 149551487}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 50
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 120, y: 0}
+  m_Spacing: {x: 0, y: 0}
+  m_Constraint: 0
+  m_ConstraintCount: 1
 --- !u!1 &152982448
 GameObject:
   m_ObjectHideFlags: 0
@@ -781,7 +973,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1880474394802326500, guid: 80a0e36580b14449684c7d9d960c6ba2, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 1880474394802326500, guid: 80a0e36580b14449684c7d9d960c6ba2, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1206,7 +1398,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6858262836679624501, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
       propertyPath: m_Name
-      value: LevelUpCost_01
+      value: GemsLevelUpCost
       objectReference: {fileID: 0}
     - target: {fileID: 6858262836918322556, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
       propertyPath: m_Sprite
@@ -2097,6 +2289,8 @@ MonoBehaviour:
   unitLevelText: {fileID: 1839430508}
   unitTierText: {fileID: 1923764974}
   levelUpGoldCostText: {fileID: 6858262836781891746}
+  tierUpGemsCostText: {fileID: 780785344}
+  tierUpGoldCostText: {fileID: 672666}
   levelUpSound: {fileID: 662620889}
 --- !u!4 &625935471
 Transform:
@@ -2933,6 +3127,135 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 752007113}
   m_CullTransparentMesh: 0
+--- !u!1001 &780785342
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 149551488}
+    m_Modifications:
+    - target: {fileID: 6858262836634528697, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_text
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 528.7149
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836679624501, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_Name
+      value: GemsLevelUpCost
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836918322556, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 1d9c8fecc73a24c15921bb444d2c3385, type: 3}
+    - target: {fileID: 6858262836918322557, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 6858262836918322557, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 40
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+--- !u!224 &780785343 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+  m_PrefabInstance: {fileID: 780785342}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &780785344 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6858262836634528697, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+  m_PrefabInstance: {fileID: 780785342}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &808814235
 GameObject:
   m_ObjectHideFlags: 0
@@ -3130,7 +3453,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1880474394802326500, guid: 80a0e36580b14449684c7d9d960c6ba2, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 1880474394802326500, guid: 80a0e36580b14449684c7d9d960c6ba2, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5025,7 +5348,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 133597137547516588, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 133597137547516588, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_AnchorMax.x
@@ -6396,7 +6719,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 133597137547516588, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 133597137547516588, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_AnchorMax.x
@@ -6513,6 +6836,10 @@ PrefabInstance:
     - target: {fileID: 1419227374130472490, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419227374130472491, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 87
       objectReference: {fileID: 0}
     - target: {fileID: 1820677119451765637, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_AnchorMax.y
@@ -8117,6 +8444,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 182123453}
     m_Modifications:
+    - target: {fileID: 6858262836634528697, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
+      propertyPath: m_text
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6858262836679624500, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -8203,7 +8534,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6858262836679624501, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
       propertyPath: m_Name
-      value: LevelUpCost_00
+      value: GoldLevelUpCost
       objectReference: {fileID: 0}
     - target: {fileID: 6858262836918322557, guid: 226c8f6dfa61149b995339a7bf2ba479, type: 3}
       propertyPath: m_SizeDelta.x

--- a/client/Assets/Scenes/UnitDetail.unity
+++ b/client/Assets/Scenes/UnitDetail.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3708708, g: 0.37838137, b: 0.35725543, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311947, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2123,7 +2123,8 @@ MonoBehaviour:
   backgroundImage: {fileID: 653320918}
   selectedCharacterImage: {fileID: 1853082264}
   characterNameContainer: {fileID: 742182412}
-  insufficientCurrencyPopup: {fileID: 1380309362}
+  errorPopUp: {fileID: 1380309362}
+  errorPopUpText: {fileID: 655376734}
   needToTierUpPopup: {fileID: 1680039526}
   equipmentSlots:
   - {fileID: 247723784}
@@ -4015,7 +4016,7 @@ GameObject:
   - component: {fileID: 951611636}
   - component: {fileID: 951611635}
   m_Layer: 0
-  m_Name: ErrorMessage
+  m_Name: Message
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -5042,7 +5043,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 133597137547516579, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_Name
-      value: InsufficientCurrencyPopup
+      value: ErrorPopup
       objectReference: {fileID: 0}
     - target: {fileID: 133597137547516579, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_IsActive
@@ -5178,7 +5179,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6992527488023465669, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_text
-      value: buy more
+      value: continue
       objectReference: {fileID: 0}
     - target: {fileID: 8504881325326043790, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_AnchorMax.y
@@ -6505,7 +6506,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1034708200250406556, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_text
-      value: Error
+      value: Tier Up
       objectReference: {fileID: 0}
     - target: {fileID: 1374520013353734708, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_AnchorMax.y
@@ -6518,6 +6519,34 @@ PrefabInstance:
     - target: {fileID: 1374520013353734708, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_SizeDelta.x
       value: 328.34338
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419227374130472490, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419227374130472490, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419227374130472490, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 625935470}
+    - target: {fileID: 1419227374130472490, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419227374130472490, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: TierUp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419227374130472490, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UnitDetail, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1419227374130472490, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 1820677119451765637, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_AnchorMax.y
@@ -6535,9 +6564,41 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: 328.34338
       objectReference: {fileID: 0}
+    - target: {fileID: 3365691818372835219, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_Name
+      value: CloseButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304672702860395076, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_Color.b
+      value: 0.38039216
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304672702860395076, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_Color.g
+      value: 0.43529412
+      objectReference: {fileID: 0}
+    - target: {fileID: 4304672702860395076, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_Color.r
+      value: 0.078431375
+      objectReference: {fileID: 0}
+    - target: {fileID: 5344732989564027012, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_Color.a
+      value: 0.7215686
+      objectReference: {fileID: 0}
+    - target: {fileID: 5344732989564027012, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_Color.b
+      value: 0.38431373
+      objectReference: {fileID: 0}
+    - target: {fileID: 5344732989564027012, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_Color.g
+      value: 0.43529412
+      objectReference: {fileID: 0}
+    - target: {fileID: 5344732989564027012, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
+      propertyPath: m_Color.r
+      value: 0.078431375
+      objectReference: {fileID: 0}
     - target: {fileID: 6992527488023465669, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_text
-      value: Ok
+      value: Tier Up
       objectReference: {fileID: 0}
     - target: {fileID: 8504881325326043790, guid: 376fe761576f5457bb52f16e42ab2860, type: 3}
       propertyPath: m_AnchorMax.y

--- a/client/Assets/Scenes/UnitDetail.unity
+++ b/client/Assets/Scenes/UnitDetail.unity
@@ -422,43 +422,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 97203767}
   m_CullTransparentMesh: 0
---- !u!1 &140261935
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 140261936}
-  m_Layer: 5
-  m_Name: UnitClass
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &140261936
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 140261935}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 354520003}
-  m_Father: {fileID: 1795223317}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.3, y: 0.23}
-  m_AnchorMax: {x: 0.7, y: 0.28}
-  m_AnchoredPosition: {x: 0, y: 964}
-  m_SizeDelta: {x: 0, y: 0.0000076293945}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &152982448
 GameObject:
   m_ObjectHideFlags: 0
@@ -1698,7 +1661,7 @@ GameObject:
   - component: {fileID: 354520005}
   - component: {fileID: 354520004}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: UnitClassText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1711,17 +1674,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 354520002}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 140261936}
-  m_RootOrder: 0
+  m_Father: {fileID: 695023166}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -19}
+  m_AnchoredPosition: {x: 0, y: -81}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &354520004
@@ -2132,6 +2095,7 @@ MonoBehaviour:
   - {fileID: 369244518153740541}
   - {fileID: 1490731956}
   unitLevelText: {fileID: 1839430508}
+  unitTierText: {fileID: 1923764974}
   levelUpGoldCostText: {fileID: 6858262836781891746}
   levelUpSound: {fileID: 662620889}
 --- !u!4 &625935471
@@ -2825,7 +2789,7 @@ GameObject:
   m_Component:
   - component: {fileID: 695023166}
   m_Layer: 5
-  m_Name: UnitLevel
+  m_Name: UnitData
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2845,6 +2809,8 @@ RectTransform:
   m_Children:
   - {fileID: 4840794578346809079}
   - {fileID: 1839430507}
+  - {fileID: 1923764973}
+  - {fileID: 354520003}
   m_Father: {fileID: 1795223317}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2884,7 +2850,7 @@ RectTransform:
   - {fileID: 322127136}
   - {fileID: 1509052181}
   m_Father: {fileID: 1795223317}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.8}
   m_AnchorMax: {x: 1, y: 0.95}
@@ -7282,7 +7248,7 @@ GameObject:
   - component: {fileID: 1839430509}
   - component: {fileID: 1839430508}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: UnitLevelText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -7305,7 +7271,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 5}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1839430508
@@ -7481,6 +7447,141 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1923764972
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1923764973}
+  - component: {fileID: 1923764975}
+  - component: {fileID: 1923764974}
+  m_Layer: 5
+  m_Name: UnitTierText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1923764973
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1923764972}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 695023166}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -38}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1923764974
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1923764972}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Tier 1
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7acb85422e77346ba8edcfa489c617af, type: 2}
+  m_sharedMaterial: {fileID: -6068340767680993057, guid: 7acb85422e77346ba8edcfa489c617af, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4288327614
+  m_fontColor: {r: 0.74509805, g: 0.6862745, b: 0.6039216, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 0.9647059, b: 0.7137255, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 0.59607846, g: 0.5647059, b: 0.5058824, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1923764975
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1923764972}
+  m_CullTransparentMesh: 1
 --- !u!1 &1937544738
 GameObject:
   m_ObjectHideFlags: 0
@@ -7697,7 +7798,7 @@ RectTransform:
   - {fileID: 1146944949}
   - {fileID: 1167859776}
   m_Father: {fileID: 1795223317}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0.225}
@@ -7960,7 +8061,7 @@ RectTransform:
   m_GameObject: {fileID: 4627193413812840965}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 1.3, z: 1}
+  m_LocalScale: {x: 0.5, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 695023166}

--- a/client/Assets/Scripts/BackendConnection/SocketConnection.cs
+++ b/client/Assets/Scripts/BackendConnection/SocketConnection.cs
@@ -643,6 +643,24 @@ public class SocketConnection : MonoBehaviour
         SendWebSocketMessage(request);
     }
 
+    public void TierUpUnit(string userId, string unitId, Action<Protobuf.Messages.UnitAndCurrencies> onUnitAndCurrenciesDataReceived, Action<string> onError)
+    {
+        TierUpUnit tierUpUnitRequest = new TierUpUnit
+        {
+            UserId = userId,
+            UnitId = unitId
+        };
+        WebSocketRequest request = new WebSocketRequest
+        {
+            TierUpUnit = tierUpUnitRequest
+        };
+        currentMessageHandler = (data) => AwaitUnitAndCurrenciesReponse(data, onUnitAndCurrenciesDataReceived, onError);
+        ws.OnMessage += currentMessageHandler;
+        ws.OnMessage -= OnWebSocketMessage;
+        SendWebSocketMessage(request);
+    }
+
+
     private void AwaitUnitAndCurrenciesReponse(byte[] data, Action<Protobuf.Messages.UnitAndCurrencies> onUnitAndCurrenciesDataReceived, Action<string> onError = null)
     {
         try

--- a/client/Assets/Scripts/BackendConnection/SocketConnection.cs
+++ b/client/Assets/Scripts/BackendConnection/SocketConnection.cs
@@ -221,6 +221,7 @@ public class SocketConnection : MonoBehaviour
             character = availableCharacters.Find(character => character.name.ToLower() == unitData.Character.Name.ToLower()),
             rank = (Rank)unitData.Rank,
             level = (int)unitData.Level,
+            tier = (int)unitData.Tier,
             slot = (int?)unitData.Slot,
             selected = unitData.Selected
         };

--- a/client/Assets/Scripts/Unit.cs
+++ b/client/Assets/Scripts/Unit.cs
@@ -6,6 +6,7 @@ public class Unit
 {
     public string id { get; set; }
     public int level { get; set; }
+    public int tier { get; set; }
     public Character character { get; set; }
     public int? slot { get; set; }
     public bool selected { get; set; }

--- a/client/Assets/Scripts/UnitDetail/UnitDetail.cs
+++ b/client/Assets/Scripts/UnitDetail/UnitDetail.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 public class UnitDetail : MonoBehaviour
@@ -20,7 +19,10 @@ public class UnitDetail : MonoBehaviour
     GameObject characterNameContainer;
 
     [SerializeField]
-    GameObject insufficientCurrencyPopup;
+    GameObject errorPopUp;
+
+    [SerializeField]
+    TextMeshProUGUI errorPopUpText;
 
     [SerializeField]
     GameObject needToTierUpPopup;
@@ -37,9 +39,6 @@ public class UnitDetail : MonoBehaviour
     [SerializeField]
     AudioSource levelUpSound;
 
-    // true if we're leveling up, false if we're tiering up
-    private bool actionLevelUp;
-
     void Start()
     {
         SetUpEquipment();
@@ -52,23 +51,15 @@ public class UnitDetail : MonoBehaviour
         SocketConnection.Instance.LevelUpUnit(GlobalUserData.Instance.User.id, selectedUnit.id,
         (unitAndCurrencies) =>
         {
-            foreach (var userCurrency in unitAndCurrencies.UserCurrency)
-            {
-                GlobalUserData.Instance.SetCurrencyAmount(userCurrency.Currency.Name, (int)userCurrency.Amount);
-            }
-            levelUpSound.Play();
-            // Should this be encapsulated somewhere?
-            GlobalUserData.Instance.User.units.Find(unit => unit.id == unitAndCurrencies.Unit.Id).level++;
-            ;
-            unitLevelText.text = $"Level: {selectedUnit.level}";
-            levelUpGoldCostText.text = ((int)Math.Pow(selectedUnit.level, 2)).ToString();
+            UpdateUserCurrenciesAndCosts(unitAndCurrencies);
         },
         (reason) =>
         {
             switch (reason)
             {
                 case "cant_afford":
-                    insufficientCurrencyPopup.SetActive(true);
+                    errorPopUpText.text = "Not enough currency";
+                    errorPopUp.SetActive(true);
                     break;
                 case "cant_level_up":
                     needToTierUpPopup.SetActive(true);
@@ -79,6 +70,33 @@ public class UnitDetail : MonoBehaviour
             }
         });
     }
+
+    public void TierUp()
+    {
+        SocketConnection.Instance.TierUpUnit(GlobalUserData.Instance.User.id, selectedUnit.id,
+        (unitAndCurrencies) =>
+        {
+            UpdateUserCurrenciesAndCosts(unitAndCurrencies);
+        },
+        (reason) =>
+        {
+            switch (reason)
+            {
+                case "cant_afford":
+                    errorPopUpText.text = "Not enough currency";
+                    errorPopUp.SetActive(true);
+                    break;
+                case "cant_tier_up":
+                    errorPopUpText.text = "Need to rank up first";
+                    errorPopUp.SetActive(true);
+                    break;
+                default:
+                    Debug.LogError(reason);
+                    break;
+            }
+        });
+    }
+
 
     // I think both SelectUnit and GetSelectedUnit should be removed and the selectedUnit field be made public
     public static void SelectUnit(Unit unit)
@@ -116,7 +134,7 @@ public class UnitDetail : MonoBehaviour
         // Hardcoded to check for gold
         if (item.GetLevelUpCost() > GlobalUserData.Instance.GetCurrency("Gold"))
         {
-            insufficientCurrencyPopup.SetActive(true);
+            errorPopUp.SetActive(true);
             return;
         }
         SocketConnection.Instance.LevelUpItem(GlobalUserData.Instance.User.id, item.id, (item) =>
@@ -126,7 +144,7 @@ public class UnitDetail : MonoBehaviour
         {
             if (reason == "cant_afford")
             {
-                insufficientCurrencyPopup.SetActive(true);
+                errorPopUp.SetActive(true);
             }
         });
     }
@@ -199,5 +217,18 @@ public class UnitDetail : MonoBehaviour
 
         Unit nextUnit = userUnits[nextIndex];
         SelectUnit(nextUnit);
+    }
+
+    private void UpdateUserCurrenciesAndCosts(Protobuf.Messages.UnitAndCurrencies unitAndCurrencies)
+    {
+        foreach (var userCurrency in unitAndCurrencies.UserCurrency)
+        {
+            GlobalUserData.Instance.SetCurrencyAmount(userCurrency.Currency.Name, (int)userCurrency.Amount);
+        }
+        levelUpSound.Play();
+        GlobalUserData.Instance.User.units.Find(unit => unit.id == unitAndCurrencies.Unit.Id).level = (int)unitAndCurrencies.Unit.Level;
+
+        unitLevelText.text = $"Level: {unitAndCurrencies.Unit.Level}";
+        levelUpGoldCostText.text = ((int)Math.Pow(unitAndCurrencies.Unit.Level, 2)).ToString();
     }
 }

--- a/client/Assets/Scripts/UnitDetail/UnitDetail.cs
+++ b/client/Assets/Scripts/UnitDetail/UnitDetail.cs
@@ -40,6 +40,12 @@ public class UnitDetail : MonoBehaviour
     TMP_Text levelUpGoldCostText;
 
     [SerializeField]
+    TMP_Text tierUpGemsCostText;
+
+    [SerializeField]
+    TMP_Text tierUpGoldCostText;
+
+    [SerializeField]
     AudioSource levelUpSound;
 
     void Start()
@@ -65,6 +71,8 @@ public class UnitDetail : MonoBehaviour
                     errorPopUp.SetActive(true);
                     break;
                 case "cant_level_up":
+                    tierUpGoldCostText.text = ((int)Math.Pow(selectedUnit.level, 2)).ToString();
+                    tierUpGemsCostText.text = "50";
                     needToTierUpPopup.SetActive(true);
                     break;
                 default:

--- a/client/Assets/Scripts/UnitDetail/UnitDetail.cs
+++ b/client/Assets/Scripts/UnitDetail/UnitDetail.cs
@@ -34,6 +34,9 @@ public class UnitDetail : MonoBehaviour
     TMP_Text unitLevelText;
 
     [SerializeField]
+    TMP_Text unitTierText;
+
+    [SerializeField]
     TMP_Text levelUpGoldCostText;
 
     [SerializeField]
@@ -186,6 +189,7 @@ public class UnitDetail : MonoBehaviour
         characterNameContainer.GetComponentInChildren<TextMeshProUGUI>().text = selectedUnit.character.name;
         characterNameContainer.SetActive(true);
         unitLevelText.text = $"Level: {selectedUnit.level}";
+        unitTierText.text = $"Tier: {selectedUnit.tier}";
         levelUpGoldCostText.text = ((int)Math.Pow(selectedUnit.level, 2)).ToString();
     }
 
@@ -229,6 +233,7 @@ public class UnitDetail : MonoBehaviour
         GlobalUserData.Instance.User.units.Find(unit => unit.id == unitAndCurrencies.Unit.Id).level = (int)unitAndCurrencies.Unit.Level;
 
         unitLevelText.text = $"Level: {unitAndCurrencies.Unit.Level}";
+        unitTierText.text = $"Tier: {unitAndCurrencies.Unit.Tier}";
         levelUpGoldCostText.text = ((int)Math.Pow(unitAndCurrencies.Unit.Level, 2)).ToString();
     }
 }


### PR DESCRIPTION
Closes #263 

## Motivation

We weren't able to tier up our units once the max level of a tier was reached.

## Summary of changes

Add a tier up pop up with a button that allows tiering up the unit. Also, once the max tier of a rank has been reached, an error pop up is shown.

## How has this been tested?

1. Start the backend and add currency to your user by running: `GameBackend.Users.Currencies.add_currency_by_name_and_game!(user_id, "Gold", 2, 2000000)`
2. Go to the barracks and pick the unit you'll level up.
3. Level your unit up to level 20 and, when trying to level it up once more, make sure that you see the tier up pop up. 
4. Use the tier up button, and now you should be able to level up your unit once more. Check that the correct level is shown in the screen, and that the level up costs are being properly updated across this process.
5. Continue leveling and tiering up until you reach the max level of the max tier. When you try to tier up, you should now see an error pop up telling you that you must rank up your unit.

## Checklist
- [X] I have tested the changes locally.
- [X] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
