### PR TITLE
Fix multiple SocketConnections in Overworld 

### DIFF
--- a/client/Assets/Scripts/BackendConnection/ServerSelect.cs
+++ b/client/Assets/Scripts/BackendConnection/ServerSelect.cs
@@ -25,8 +25,8 @@ public class ServerSelect : MonoBehaviour
         if (string.IsNullOrEmpty(ServerSelect.Name) || string.IsNullOrEmpty(ServerSelect.Domain))
         {
 #if UNITY_EDITOR
-				ServerSelect.Name = "LOCALHOST";
-				ServerSelect.Domain = servers["LOCALHOST"];
+            ServerSelect.Name = "LOCALHOST";
+            ServerSelect.Domain = servers["LOCALHOST"];
 #else
             ServerSelect.Name = "EUROPE";
             ServerSelect.Domain = servers["EUROPE"];
@@ -41,7 +41,7 @@ public class ServerSelect : MonoBehaviour
         ServerSelect.Domain = servers[domainName];
         serverButtonText.text = ServerSelect.Name;
         await SocketConnection.Instance.CloseConnection();
-        SocketConnection.Instance.Init();
+        SocketConnection.Instance.ConnectToSession();
     }
 
     public async void SelectCustomServer()
@@ -49,6 +49,6 @@ public class ServerSelect : MonoBehaviour
         ServerSelect.Name = "CUSTOM";
         ServerSelect.Domain = customServerDomain.text;
         await SocketConnection.Instance.CloseConnection();
-        SocketConnection.Instance.Init();
+        SocketConnection.Instance.ConnectToSession();
     }
 }

--- a/client/Assets/Scripts/BackendConnection/SocketConnection.cs
+++ b/client/Assets/Scripts/BackendConnection/SocketConnection.cs
@@ -26,13 +26,19 @@ public class SocketConnection : MonoBehaviour
 
     public void Init()
     {
-        Instance = this;
-        DontDestroyOnLoad(gameObject);
-
-        if (!connected)
+        if (Instance == null)
         {
-            connected = true;
-            ConnectToSession();
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            if (!connected)
+            {
+                ConnectToSession();
+            }
+        }
+        else
+        {
+            // Destroy this instance if another one already exists
+            Destroy(gameObject);
         }
     }
 
@@ -51,8 +57,9 @@ public class SocketConnection : MonoBehaviour
         await this.CloseConnection();
     }
 
-    private void ConnectToSession()
+    public void ConnectToSession()
     {
+        Debug.Log("SocketConnection ConnectToSession");
         string url = $"{ServerSelect.Domain}/2";
         ws = new WebSocket(url);
         ws.OnMessage += OnWebSocketMessage;
@@ -66,6 +73,7 @@ public class SocketConnection : MonoBehaviour
             Debug.LogError("Received error: " + e);
         };
         ws.Connect();
+        connected = true;
     }
 
     private void OnWebsocketClose(WebSocketCloseCode closeCode)


### PR DESCRIPTION
Closes #448

## Motivation

A new SocketConnection was being instantiated every time we went into the Overworld scene, which started a new WS connection.

With this PR we singletonize the singleton (? to actually keep it as the unique instance.

We also need to fix the ServerSelect stuff a bit: if we called Init there, we would get an unexisting gameobject error. Instead, we use the currently existing singleton instance, connecting to the newly configured domain.

## Summary of changes

- Fix singleton pattern in SocketConnection.cs
- Fix SelectServer.cs's usage of Socketconnection.cs

## How has this been tested?

Play around with the swapping of servers and entering and leaving the Overworld scene. When connecting to localhost, you should see one `[info] Websocket INIT called` log in the server for each time you connected to the backend through the Server Selector, and not one for each time you entered the Overworld scene.

## Test additions / changes

List tests added/updated.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
